### PR TITLE
attempting to fix the failure in tutorial 4

### DIFF
--- a/markdowns/4.md
+++ b/markdowns/4.md
@@ -172,7 +172,7 @@ print(df.head())
 
 # Get embeddings for our questions from the FAQs
 questions = list(df["question"].values)
-df["question_emb"] = retriever.embed_queries(queries=questions)
+df["question_emb"] = retriever.embed_queries(queries=questions).tolist()
 df = df.rename(columns={"question": "content"})
 
 # Convert Dataframe to list of dicts and index them in our DocumentStore

--- a/markdowns/4.md
+++ b/markdowns/4.md
@@ -172,7 +172,7 @@ print(df.head())
 
 # Get embeddings for our questions from the FAQs
 questions = list(df["question"].values)
-df["question_emb"] = retriever.embed_queries(texts=questions)
+df["question_emb"] = retriever.embed_queries(queries=questions)
 df = df.rename(columns={"question": "content"})
 
 # Convert Dataframe to list of dicts and index them in our DocumentStore

--- a/tutorials/04_FAQ_style_QA.ipynb
+++ b/tutorials/04_FAQ_style_QA.ipynb
@@ -298,7 +298,7 @@
     "\n",
     "# Get embeddings for our questions from the FAQs\n",
     "questions = list(df[\"question\"].values)\n",
-    "df[\"question_emb\"] = retriever.embed_queries(texts=questions)\n",
+    "df[\"question_emb\"] = retriever.embed_queries(queries=questions)\n",
     "df = df.rename(columns={\"question\": \"content\"})\n",
     "\n",
     "# Convert Dataframe to list of dicts and index them in our DocumentStore\n",
@@ -376,7 +376,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.9 64-bit",
+   "display_name": "Python 3.10.4 ('haystack-tutorials')",
    "language": "python",
    "name": "python3"
   },
@@ -390,11 +390,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.9"
+   "version": "3.10.4"
   },
   "vscode": {
    "interpreter": {
-    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+    "hash": "1e4fa2e1c496b8379da88afac82c60055e1be33cd79040f849449f398c153e43"
    }
   }
  },

--- a/tutorials/04_FAQ_style_QA.ipynb
+++ b/tutorials/04_FAQ_style_QA.ipynb
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -298,7 +298,7 @@
     "\n",
     "# Get embeddings for our questions from the FAQs\n",
     "questions = list(df[\"question\"].values)\n",
-    "df[\"question_emb\"] = retriever.embed_queries(queries=questions)\n",
+    "df[\"question_emb\"] = retriever.embed_queries(queries=questions).tolist()\n",
     "df = df.rename(columns={\"question\": \"content\"})\n",
     "\n",
     "# Convert Dataframe to list of dicts and index them in our DocumentStore\n",
@@ -318,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false,
     "pycharm": {


### PR DESCRIPTION
@masci Tutorial 4 was failing because a parameter name for `.embed_queries` was changed. I'm trying to fix that in this PR. 
Maybe this is one of those cases where we add a banner or something saying that this won't work with versions before X? But it might also be too minor to bother :) 