### PR TITLE
Align `black` config with Haystack repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,9 +10,10 @@ repos:
     - id: no-commit-to-branch  # prevents committing to main
 
 - repo: https://github.com/psf/black
-  rev: 22.6.0  # IMPORTANT: keep this aligned with the black version in pyproject.toml
+  rev: 22.6.0
   hooks:
   - id: black-jupyter
+    entry: black --skip-magic-trailing-comma --line-length 120  
 
 - repo: local
   hooks:


### PR DESCRIPTION
In #4, I said:
> If I try to run pre-commit run --all-files, it seems that black-jupyter (22.6.0) wants to reformat all the notebooks. 

@masci:
> we never run a formatter on the notebooks, I think this is a good opportunity to do it. The only problem I see, it's already hard to port changes from the haystack repo now, if we re-format the files it'll be impossible. So I would re-format all the things only if we're close enough to remove the files from the haystack repo. WDYT?

@masci @TuanaCelik I found out what the problem is:
**in Haystack repo we are running black with the configurations specified in pyproject.toml**:
```
[tool.black]
line-length = 120
skip_magic_trailing_comma = true  # For compatibility with pydoc>=4.6, check if still needed.
```

### Proposed changes
In this PR, I fix this misalignment, by adding these parameters to the black entry in .pre-commit-config.yaml
Another option could be to add pyproject.toml to this repo: maybe it is premature or not wanted/needed.