### PR TITLE
Fixed old tutorial link with new one

### DIFF
--- a/tutorials/11_Pipelines.ipynb
+++ b/tutorials/11_Pipelines.ipynb
@@ -11,7 +11,7 @@
    "source": [
     "# Pipelines Tutorial\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack/blob/main/tutorials/Tutorial11_Pipelines.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/11_Pipelines.ipynb)\n",
     "\n",
     "In this tutorial, you will learn how the `Pipeline` class acts as a connector between all the different\n",
     "building blocks that are found in FARM. Whether you are using a Reader, Generator, Summarizer\n",


### PR DESCRIPTION
The link to the Colab tutorial was not updated yet to point to haystack-tutorials.
The new link now is:
https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/11_Pipelines.ipynb