### PR TITLE
Redeploy Haystack Home when tutorials are changed

### DIFF
--- a/.github/workflows/publish_tutorials.yml
+++ b/.github/workflows/publish_tutorials.yml
@@ -1,0 +1,17 @@
+name: Publish tutorials on Haystack Home
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+
+jobs:
+  publish-tutorials:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: trigger-hook
+        run: |
+          curl -X POST ${{ secrets.VERCEL_DEPLOY_HOOK }}


### PR DESCRIPTION
This workflow will trigger a deploy of Haystack Home `prod` at every merge on `main`. Haystack Home build script will fetch the updated tutorials and update the website contents.

Blocked on https://github.com/deepset-ai/haystack-home/pull/25