### PR TITLE
re-adding colab buttons to .ipynb

### DIFF
--- a/markdowns/01_Basic_QA_Pipeline.md
+++ b/markdowns/01_Basic_QA_Pipeline.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/01_Basic_QA_Pipeline.ipynb
 toc: True
 title: "Build Your First QA System"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "beginner"
 weight: 10
 description: Get Started by creating a Retriever Reader pipeline.

--- a/markdowns/02_Finetune_a_model_on_your_data.md
+++ b/markdowns/02_Finetune_a_model_on_your_data.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/02_Finetune_a_model_on_your_data.ipynb
 toc: True
 title: "Fine-Tuning a Model on Your Own Data"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "intermediate"
 weight: 50
 description: Improve the performance of your Reader by performing fine-tuning.

--- a/markdowns/03_Basic_QA_Pipeline_without_Elasticsearch.md
+++ b/markdowns/03_Basic_QA_Pipeline_without_Elasticsearch.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/03_Basic_QA_Pipeline_without_Elasticsearch.ipynb
 toc: True
 title: "Build a QA System Without Elasticsearch"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "beginner"
 weight: 15
 description: Create a Retriever Reader pipeline that requires no external database dependencies.

--- a/markdowns/04_FAQ_style_QA.md
+++ b/markdowns/04_FAQ_style_QA.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/04_FAQ_style_QA.ipynb
 toc: True
 title: "Utilizing Existing FAQs for Question Answering"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "beginner"
 weight: 20
 description: Create a smarter way to answer new questions using your existing FAQ documents.

--- a/markdowns/05_Evaluation.md
+++ b/markdowns/05_Evaluation.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/05_Evaluation.ipynb
 toc: True
 title: "Evaluation of a QA System"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "advanced"
 weight: 100
 description: Learn how to evaluate the performance of individual nodes as well as entire pipelines.

--- a/markdowns/06_Better_Retrieval_via_Embedding_Retrieval.md
+++ b/markdowns/06_Better_Retrieval_via_Embedding_Retrieval.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/06_Better_Retrieval_via_Embedding_Retrieval.ipynb
 toc: True
 title: "Better Retrieval with Embedding Retrieval"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "intermediate"
 weight: 55
 description: Use Transformer based dense Retrievers to improve your system’s performance.

--- a/markdowns/07_RAG_Generator.md
+++ b/markdowns/07_RAG_Generator.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/07_RAG_Generator.ipynb
 toc: True
 title: "Generative QA with Retrieval-Augmented Generation"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "intermediate"
 weight: 60
 description: Try out a generative model in place of the extractive Reader.

--- a/markdowns/08_Preprocessing.md
+++ b/markdowns/08_Preprocessing.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/08_Preprocessing.ipynb
 toc: True
 title: "Preprocessing Your Documents"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "beginner"
 weight: 25
 description: Start converting, cleaning, and splitting Documents using Haystack’s preprocessing capabilities.

--- a/markdowns/09_DPR_training.md
+++ b/markdowns/09_DPR_training.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/09_DPR_training.ipynb
 toc: True
 title: "Training Your Own Dense Passage Retrieval Model"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "advanced"
 weight: 110
 description: Learn about training a Dense Passage Retrieval model and the data needed to do so.

--- a/markdowns/10_Knowledge_Graph.md
+++ b/markdowns/10_Knowledge_Graph.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/10_Knowledge_Graph.ipynb
 toc: True
 title: "Question Answering on a Knowledge Graph"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "advanced"
 weight: 120
 description: Experiment with a question answering system that draws upon knowledge graph.h

--- a/markdowns/11_Pipelines.md
+++ b/markdowns/11_Pipelines.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/11_Pipelines.ipynb
 toc: True
 title: "How to Use Pipelines"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "intermediate"
 weight: 65
 description: Learn about the many ways which you can route queries through the nodes in a pipeline.

--- a/markdowns/12_LFQA.md
+++ b/markdowns/12_LFQA.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/12_LFQA.ipynb
 toc: True
 title: "Generatice QA with LFQA"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "intermediate"
 weight: 70
 description: Try out a generative model in place of the extractive Reader.

--- a/markdowns/13_Question_generation.md
+++ b/markdowns/13_Question_generation.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/13_Question_generation.ipynb
 toc: True
 title: "Question Generation"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "intermediate"
 weight: 75
 description: Generate a set of questions that can be answered by a given Document.

--- a/markdowns/14_Query_Classifier.md
+++ b/markdowns/14_Query_Classifier.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/14_Query_Classifier.ipynb
 toc: True
 title: "Query Classifier"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "intermediate"
 weight: 80
 description: Classify incoming queries so that they can be routed to the nodes that are best at handling them.

--- a/markdowns/15_TableQA.md
+++ b/markdowns/15_TableQA.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/15_TableQA.ipynb
 toc: True
 title: "Open-Domain QA on Tables"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "advanced"
 weight: 130
 description: Perform question answering on tabular data.

--- a/markdowns/16_Document_Classifier_at_Index_Time.md
+++ b/markdowns/16_Document_Classifier_at_Index_Time.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/16_Document_Classifier_at_Index_Time.ipynb
 toc: True
 title: "Document Classification at Index Time"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "intermediate"
 weight: 85
 description: Generate and attach classification labels to your Documents when indexing.

--- a/markdowns/17_Audio.md
+++ b/markdowns/17_Audio.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/17_Audio.ipynb
 toc: True
 title: "Make Your QA Pipelines Talk!"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "intermediate"
 weight: 90
 description: Convert text Answers into speech.

--- a/markdowns/18_GPL.md
+++ b/markdowns/18_GPL.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/18_GPL.ipynb
 toc: True
 title: "Generative Pseudo Labeling for Domain Adaptation"
-last_updated: 2022-10-12
+last_updated: 2022-10-24
 level: "advanced"
 weight: 140
 description: Use a Retriever and a query generator to perform unsupervised domain adaptation.

--- a/scripts/generate_markdowns.py
+++ b/scripts/generate_markdowns.py
@@ -1,7 +1,9 @@
 import argparse
 from datetime import date
+from bs4 import Tag
 import tomli
 from nbconvert import MarkdownExporter
+from nbconvert.preprocessors import TagRemovePreprocessor
 
 def read_index(path):
     with open(path, "rb") as f:
@@ -32,7 +34,10 @@ aliases: {aliases}
 
 def generate_markdown_from_notebook(config, tutorial, output_path, tutorials_path):
     frontmatter = generate_frontmatter(config, tutorial)
+    preprocessor = TagRemovePreprocessor()
+    preprocessor.remove_cell_tags = ("skip")
     md_exporter = MarkdownExporter(exclude_output=True)
+    md_exporter.register_preprocessor(preprocessor, True)
     body, _ = md_exporter.from_filename(f"{tutorials_path}")
     print(f"Processing {tutorials_path}")
 

--- a/tutorials/01_Basic_QA_Pipeline.ipynb
+++ b/tutorials/01_Basic_QA_Pipeline.ipynb
@@ -2,6 +2,18 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/01_Basic_QA_Pipeline.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Build Your First QA System\n",

--- a/tutorials/02_Finetune_a_model_on_your_data.ipynb
+++ b/tutorials/02_Finetune_a_model_on_your_data.ipynb
@@ -2,6 +2,18 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/02_Finetune_a_model_on_your_data.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Fine-tuning a Model on Your Own Data\n",

--- a/tutorials/03_Basic_QA_Pipeline_without_Elasticsearch.ipynb
+++ b/tutorials/03_Basic_QA_Pipeline_without_Elasticsearch.ipynb
@@ -2,6 +2,18 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/03_Basic_QA_Pipeline_without_Elasticsearch.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Build a QA System Without Elasticsearch\n",

--- a/tutorials/04_FAQ_style_QA.ipynb
+++ b/tutorials/04_FAQ_style_QA.ipynb
@@ -2,6 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/04_FAQ_style_QA.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Utilizing existing FAQs for Question Answering\n",

--- a/tutorials/05_Evaluation.ipynb
+++ b/tutorials/05_Evaluation.ipynb
@@ -3,6 +3,17 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/05_Evaluation.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "collapsed": false
    },
    "source": [
@@ -1177,7 +1188,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.10.6 64-bit",
+   "display_name": "Python 3.10.4 ('haystack-tutorials')",
    "language": "python",
    "name": "python3"
   },
@@ -1191,11 +1202,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.4"
   },
   "vscode": {
    "interpreter": {
-    "hash": "bda33b16be7e844498c7c2d368d72665b4f1d165582b9547ed22a0249a29ca2e"
+    "hash": "1e4fa2e1c496b8379da88afac82c60055e1be33cd79040f849449f398c153e43"
    }
   },
   "widgets": {

--- a/tutorials/06_Better_Retrieval_via_Embedding_Retrieval.ipynb
+++ b/tutorials/06_Better_Retrieval_via_Embedding_Retrieval.ipynb
@@ -3,6 +3,17 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "tags": [
+          "skip"
+        ]
+      },
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/06_Better_Retrieval_via_Embedding_Retrieval.ipynb)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "bEH-CRbeA6NU"
       },
       "source": [

--- a/tutorials/07_RAG_Generator.ipynb
+++ b/tutorials/07_RAG_Generator.ipynb
@@ -3,6 +3,17 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/07_RAG_Generator.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "collapsed": false
    },
    "source": [

--- a/tutorials/08_Preprocessing.ipynb
+++ b/tutorials/08_Preprocessing.ipynb
@@ -3,6 +3,17 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/08_Preprocessing.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "collapsed": false
    },
    "source": [

--- a/tutorials/09_DPR_training.ipynb
+++ b/tutorials/09_DPR_training.ipynb
@@ -3,6 +3,17 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/09_DPR_training.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/10_Knowledge_Graph.ipynb
+++ b/tutorials/10_Knowledge_Graph.ipynb
@@ -3,6 +3,17 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/10_Knowledge_Graph.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "pycharm": {
      "name": "#%% md\n"
     }

--- a/tutorials/11_Pipelines.ipynb
+++ b/tutorials/11_Pipelines.ipynb
@@ -3,6 +3,17 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack/blob/main/tutorials/Tutorial11_Pipelines.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/12_LFQA.ipynb
+++ b/tutorials/12_LFQA.ipynb
@@ -3,6 +3,17 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/12_LFQA.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "id": "bEH-CRbeA6NU"
    },
    "source": [

--- a/tutorials/13_Question_generation.ipynb
+++ b/tutorials/13_Question_generation.ipynb
@@ -3,6 +3,17 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/13_Question_generation.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "collapsed": true,
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/14_Query_Classifier.ipynb
+++ b/tutorials/14_Query_Classifier.ipynb
@@ -3,6 +3,17 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/14_Query_Classifier.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "id": "O-W2ZQ6CN-gZ",
     "pycharm": {
      "name": "#%% md\n"

--- a/tutorials/15_TableQA.ipynb
+++ b/tutorials/15_TableQA.ipynb
@@ -3,6 +3,17 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/15_TableQA.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "id": "DeAkZwDhufYA"
    },
    "source": [

--- a/tutorials/16_Document_Classifier_at_Index_Time.ipynb
+++ b/tutorials/16_Document_Classifier_at_Index_Time.ipynb
@@ -2,6 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/16_Document_Classifier_at_Index_Time.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Extending your Metadata using DocumentClassifiers at Index Time\n",

--- a/tutorials/17_Audio.ipynb
+++ b/tutorials/17_Audio.ipynb
@@ -3,6 +3,17 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/17_Audio.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "id": "Dne2XSNzB3SK"
    },
    "source": [

--- a/tutorials/18_GPL.ipynb
+++ b/tutorials/18_GPL.ipynb
@@ -2,6 +2,18 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "fadb2173",
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/18_GPL.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
     "pycharm": {


### PR DESCRIPTION
This PR fixes #47 
We had removed these buttons because we are rendering them in `haystack-home` and we would have had duplicates, twice a button on haystack-home.
Since @julian-risch suggests that the button is useful for people reaching tutorials via GitHub, this is my proposed fix.
We add a `skip` tag to the markdown cell and ask contributors to add this markdown cell at the top of their `.ipynb` contributions.
I have set up a preprocessor which will disregard cells with the `skip` tag.
