### PR TITLE
fix: fix tutorial 11

### DIFF
--- a/markdowns/11_Pipelines.md
+++ b/markdowns/11_Pipelines.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/11_Pipelines.ipynb
 toc: True
 title: "How to Use Pipelines"
-last_updated: 2022-10-26
+last_updated: 2022-10-28
 level: "intermediate"
 weight: 65
 description: Learn about the many ways which you can route queries through the nodes in a pipeline.
@@ -142,7 +142,7 @@ bm25_retriever = BM25Retriever(document_store=document_store)
 
 # Initialize dense retriever
 embedding_retriever = EmbeddingRetriever(
-    document_store, embedding_model="sentence-transformers/multi-qa-mpnet-base-dot-v1"
+    document_store=document_store, embedding_model="sentence-transformers/multi-qa-mpnet-base-dot-v1"
 )
 document_store.update_embeddings(embedding_retriever, update_existing_embeddings=False)
 

--- a/tutorials/11_Pipelines.ipynb
+++ b/tutorials/11_Pipelines.ipynb
@@ -287,7 +287,7 @@
     "\n",
     "# Initialize dense retriever\n",
     "embedding_retriever = EmbeddingRetriever(\n",
-    "    document_store, embedding_model=\"sentence-transformers/multi-qa-mpnet-base-dot-v1\"\n",
+    "    document_store=document_store, embedding_model=\"sentence-transformers/multi-qa-mpnet-base-dot-v1\"\n",
     ")\n",
     "document_store.update_embeddings(embedding_retriever, update_existing_embeddings=False)\n",
     "\n",
@@ -860,7 +860,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "3.8.9"
+   "version": "3.10.6"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
- https://github.com/deepset-ai/haystack/pull/3379 switched some parameters in the Retriever signature. 
- Tutorial 11 was passing the document_store as an arg, so when the parameter became optional, the tutorial broke.
- This PR names the parameter, fixing the issue