### PR TITLE
Tutorial 15: install torch scatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   hooks:
     - id: tutorials-markdown
       name: Markdown version of the tutorials
-      entry: python scripts/generate_markdowns.py
+      entry: python scripts/generate_markdowns.py --notebooks
       language: system
       types: [jupyter]  
       

--- a/markdowns/15_TableQA.md
+++ b/markdowns/15_TableQA.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/15_TableQA.ipynb
 toc: True
 title: "Open-Domain QA on Tables"
-last_updated: 2022-10-12
+last_updated: 2022-10-31
 level: "advanced"
 weight: 130
 description: Perform question answering on tabular data.
@@ -43,8 +43,23 @@ pip install --upgrade pip
 pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]
 
 # Install pygraphviz for visualization of Pipelines
-!apt install libgraphviz-dev
-!pip install pygraphviz
+apt install libgraphviz-dev
+pip install pygraphviz
+```
+
+
+```python
+# The TaPAs-based TableReader requires the torch-scatter library
+import torch
+
+torch_version = torch.__version__
+```
+
+
+```bash
+%%bash -s "$torch_version"
+
+pip install torch-scatter -f https://data.pyg.org/whl/torch-$1.html
 ```
 
 ## Logging

--- a/scripts/generate_markdowns.py
+++ b/scripts/generate_markdowns.py
@@ -3,6 +3,7 @@ from datetime import date
 import tomli
 from nbconvert import MarkdownExporter
 
+
 def read_index(path):
     with open(path, "rb") as f:
         return tomli.load(f)
@@ -48,16 +49,16 @@ def generate_markdown_from_notebook(config, tutorial, output_path, tutorials_pat
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--index", dest="index")
-    parser.add_argument("--notebooks", dest="notebooks", nargs='+', default=[])
+    parser.add_argument("--index", dest="index", default="index.toml")
+    parser.add_argument("--notebooks", dest="notebooks", nargs="+", default=[])
     parser.add_argument("--output", dest="output", default="markdowns")
     args = parser.parse_args()
     index = read_index(args.index)
 
     nb_to_config = {cfg["notebook"]: cfg for cfg in index["tutorial"]}
-        
+
     for notebook in args.notebooks:
-        nb_name = notebook.split('/')[-1]
+        nb_name = notebook.split("/")[-1]
         tutorial_cfg = nb_to_config.get(nb_name)
         if tutorial_cfg:
             generate_markdown_from_notebook(index["config"], tutorial_cfg, args.output, notebook)

--- a/tutorials/15_TableQA.ipynb
+++ b/tutorials/15_TableQA.ipynb
@@ -67,8 +67,39 @@
     "pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]\n",
     "\n",
     "# Install pygraphviz for visualization of Pipelines\n",
-    "!apt install libgraphviz-dev\n",
-    "!pip install pygraphviz"
+    "apt install libgraphviz-dev\n",
+    "pip install pygraphviz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The TaPAs-based TableReader requires the torch-scatter library\n",
+    "import torch\n",
+    "\n",
+    "torch_version = torch.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%bash -s \"$torch_version\"\n",
+    "\n",
+    "pip install torch-scatter -f https://data.pyg.org/whl/torch-$1.html"
    ]
   },
   {
@@ -781,7 +812,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.10.6 64-bit",
+   "display_name": "Python 3.10.4 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -795,11 +826,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.4"
   },
   "vscode": {
    "interpreter": {
-    "hash": "bda33b16be7e844498c7c2d368d72665b4f1d165582b9547ed22a0249a29ca2e"
+    "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
    }
   }
  },


### PR DESCRIPTION
I understood from https://github.com/deepset-ai/haystack/discussions/3501 that at some point the installation of torch scatter was removed from Tutorial 15.
So the tutorial doesn't run and the user has to figure out how to overcome this issue...

This PR fixes this aspect.

I also made minor fixes to pre-commit/generate_markdowns script which I think was not running correctly.