### PR TITLE
Tutorial 08: fix typos in bash cell

### DIFF
--- a/markdowns/08_Preprocessing.md
+++ b/markdowns/08_Preprocessing.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/08_Preprocessing.ipynb
 toc: True
 title: "Preprocessing Your Documents"
-last_updated: 2022-10-26
+last_updated: 2022-11-22
 level: "beginner"
 weight: 25
 description: Start converting, cleaning, and splitting Documents using Haystack’s preprocessing capabilities.
@@ -38,12 +38,12 @@ pip install --upgrade pip
 pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,ocr]
 
 # For Colab/linux based machines:
-!wget https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz
-!tar -xvf xpdf-tools-linux-4.04.tar.gz && sudo cp xpdf-tools-linux-4.04/bin64/pdftotext /usr/local/bin
+wget https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz
+tar -xvf xpdf-tools-linux-4.04.tar.gz && sudo cp xpdf-tools-linux-4.04/bin64/pdftotext /usr/local/bin
 
 # For macOS machines:
-# !wget https://dl.xpdfreader.com/xpdf-tools-mac-4.03.tar.gz
-# !tar -xvf xpdf-tools-mac-4.03.tar.gz && sudo cp xpdf-tools-mac-4.03/bin64/pdftotext /usr/local/bin
+# wget https://dl.xpdfreader.com/xpdf-tools-mac-4.03.tar.gz
+# tar -xvf xpdf-tools-mac-4.03.tar.gz && sudo cp xpdf-tools-mac-4.03/bin64/pdftotext /usr/local/bin
 ```
 
 ## Logging

--- a/markdowns/08_Preprocessing.md
+++ b/markdowns/08_Preprocessing.md
@@ -30,6 +30,16 @@ docs = [
 
 This tutorial will show you all the tools that Haystack provides to help you cast your data into this format.
 
+### Prepare environment
+
+#### Colab: Enable the GPU runtime
+Make sure you enable the GPU runtime to experience decent speed in this tutorial.
+**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
+
+<img src="https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg">
+
+You can double check whether the GPU runtime is enabled with the following command:
+
 
 ```bash
 %%bash

--- a/tutorials/08_Preprocessing.ipynb
+++ b/tutorials/08_Preprocessing.ipynb
@@ -46,6 +46,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "### Prepare environment\n",
+    "\n",
+    "#### Colab: Enable the GPU runtime\n",
+    "Make sure you enable the GPU runtime to experience decent speed in this tutorial.\n",
+    "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
+    "\n",
+    "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg\">\n",
+    "\n",
+    "You can double check whether the GPU runtime is enabled with the following command:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 26,
    "metadata": {

--- a/tutorials/08_Preprocessing.ipynb
+++ b/tutorials/08_Preprocessing.ipynb
@@ -65,12 +65,12 @@
     "pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,ocr]\n",
     "\n",
     "# For Colab/linux based machines:\n",
-    "!wget https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz\n",
-    "!tar -xvf xpdf-tools-linux-4.04.tar.gz && sudo cp xpdf-tools-linux-4.04/bin64/pdftotext /usr/local/bin\n",
+    "wget https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz\n",
+    "tar -xvf xpdf-tools-linux-4.04.tar.gz && sudo cp xpdf-tools-linux-4.04/bin64/pdftotext /usr/local/bin\n",
     "\n",
     "# For macOS machines:\n",
-    "# !wget https://dl.xpdfreader.com/xpdf-tools-mac-4.03.tar.gz\n",
-    "# !tar -xvf xpdf-tools-mac-4.03.tar.gz && sudo cp xpdf-tools-mac-4.03/bin64/pdftotext /usr/local/bin"
+    "# wget https://dl.xpdfreader.com/xpdf-tools-mac-4.03.tar.gz\n",
+    "# tar -xvf xpdf-tools-mac-4.03.tar.gz && sudo cp xpdf-tools-mac-4.03/bin64/pdftotext /usr/local/bin"
    ]
   },
   {


### PR DESCRIPTION
Leftover from when we added the `%%bash` cells. Tests didn't catch it because we don't execute shell instructions in the CI.