### PR TITLE
Remove attempt to fix PIL error

### DIFF
--- a/markdowns/08_Preprocessing.md
+++ b/markdowns/08_Preprocessing.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/08_Preprocessing.ipynb
 toc: True
 title: "Preprocessing Your Documents"
-last_updated: 2022-11-24
+last_updated: 2022-11-25
 level: "beginner"
 weight: 25
 description: Start converting, cleaning, and splitting Documents using Haystack’s preprocessing capabilities.
@@ -29,16 +29,6 @@ docs = [
 ```
 
 This tutorial will show you all the tools that Haystack provides to help you cast your data into this format.
-
-### Prepare environment
-
-#### Colab: Enable the GPU runtime
-Make sure you enable the GPU runtime to experience decent speed in this tutorial.
-**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
-
-<img src="https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg">
-
-You can double check whether the GPU runtime is enabled with the following command:
 
 
 ```bash

--- a/tutorials/08_Preprocessing.ipynb
+++ b/tutorials/08_Preprocessing.ipynb
@@ -46,23 +46,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "### Prepare environment\n",
-    "\n",
-    "#### Colab: Enable the GPU runtime\n",
-    "Make sure you enable the GPU runtime to experience decent speed in this tutorial.\n",
-    "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
-    "\n",
-    "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg\">\n",
-    "\n",
-    "You can double check whether the GPU runtime is enabled with the following command:"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 26,
    "metadata": {


### PR DESCRIPTION
GPU is not really needed for this tutorial, but enabling it seemed to be a mitigation for https://github.com/deepset-ai/haystack-tutorials/issues/76. Now that we have the actual fix shipped in Haystack with https://github.com/deepset-ai/haystack/pull/3626 we can remove the GPU trick.