### PR TITLE
Customize `colab` attribute to be able to skip Colab button and link

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -10,7 +10,7 @@ To make a request for a new tutorial or to suggest edits and fixes, submit an is
 
 ## Contributing Edits or New Tutorials
 
-All of the Haystack tutorials live in the `tutorials` folder in this repo. Each tutorial is an interactive `.ipynb` file that you can run on Google Colab, too. For each `.ipynb` file, we also generate a Markdown file to accompany it.
+All of the Haystack tutorials live in the `tutorials` folder in this repo. Each tutorial is an interactive `.ipynb` file and we generate a Markdown file to accompany it.
 
 Here's what you need to do to add or edit tutorials 👇:
 
@@ -20,7 +20,7 @@ Here's what you need to do to add or edit tutorials 👇:
    tasks right before all git commit operations.
 2. If you're creating a new tutorial:
    - Follow the [naming convention](#naming-convention-for-file-names) for file names.
-   - Add your new tutorial to [index.toml](/index.toml). Here, `weight` is the order in which your tutorial appears. For example, a tutorial with `weight = 15` comes after a tutorial with `weight = 10` and before `20`.
+   - Add your new tutorial to [index.toml](/index.toml). Here, `weight` is the order in which your tutorial appears. For example, a tutorial with `weight = 15` comes after a tutorial with `weight = 10` and before `20`. Each tutorial comes with a Google Colab link and `Open in Colab` button on the top of the tutorial by default. If your new tutorial cannot be run on Google Colab, set `colab = false` not to display `Open in Colab` button on top the tutorial.
 3. Edit an existing tutorial or copy the [tutorial template](/tutorials/template.ipynb) to create a new tutorial. 
 4. Pre-commit hooks will ensure the `markdowns` folder reflects your changes but you can update the docs at any time:
     - Run `python scripts/generate_markdowns.py --index index.toml --notebooks tutorials/your-tutorial.ipynb --output markdowns/`. This generates or updates the relevant markdown file in `/markdowns`.

--- a/scripts/generate_markdowns.py
+++ b/scripts/generate_markdowns.py
@@ -18,7 +18,7 @@ def generate_frontmatter(config, tutorial):
 
     frontmatter = f"""---
 layout: {config["layout"]}
-colab: {config["colab"]}{tutorial["notebook"]}
+colab: {tutorial.get("colab", f'{config["colab"]}{tutorial["notebook"]}')}
 toc: {config["toc"]}
 title: "{tutorial["title"]}"
 last_updated: {date.today()}
@@ -39,7 +39,7 @@ def generate_markdown_from_notebook(config, tutorial, output_path, tutorials_pat
     body, _ = md_exporter.from_filename(f"{tutorials_path}")
     body = get_lines(body, start=1)
     print(f"Processing {tutorials_path}")
-    filename = tutorial.get('slug', tutorial['notebook'][:-6])
+    filename = tutorial.get("slug", tutorial["notebook"][:-6])
     with open(f"{output_path}/{filename}.md", "w", encoding="utf-8") as f:
         try:
             f.write(frontmatter + "\n\n")


### PR DESCRIPTION
Closes #73 

Users need to set `colab = false` in `index.toml` to skip the button. This will override the frontmatter's `colab` attribute.

**To Do**
- [ ] There might be additional work to prevent publishing to Google Colab by default