### PR TITLE
feat: Remove torch-scatter reference since it is no longer needed

### DIFF
--- a/markdowns/15_TableQA.md
+++ b/markdowns/15_TableQA.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/15_TableQA.ipynb
 toc: True
 title: "Open-Domain QA on Tables"
-last_updated: 2022-12-08
+last_updated: 2022-12-15
 level: "advanced"
 weight: 130
 description: Perform question answering on tabular data.
@@ -45,21 +45,6 @@ pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[col
 # Install pygraphviz for visualization of Pipelines
 apt install libgraphviz-dev
 pip install pygraphviz
-```
-
-
-```python
-# The TaPAs-based TableReader requires the torch-scatter library
-import torch
-
-torch_version = torch.__version__
-```
-
-
-```bash
-%%bash -s "$torch_version"
-
-pip install torch-scatter -f https://data.pyg.org/whl/torch-$1.html
 ```
 
 ## Logging

--- a/tutorials/15_TableQA.ipynb
+++ b/tutorials/15_TableQA.ipynb
@@ -72,40 +72,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "shellscript"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# The TaPAs-based TableReader requires the torch-scatter library\n",
-    "import torch\n",
-    "\n",
-    "torch_version = torch.__version__"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "shellscript"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%%bash -s \"$torch_version\"\n",
-    "\n",
-    "pip install torch-scatter -f https://data.pyg.org/whl/torch-$1.html"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
@@ -123,7 +91,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
@@ -811,7 +778,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.10.4 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -825,7 +792,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.8"
   },
   "vscode": {
    "interpreter": {
@@ -834,5 +801,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Removed torch-scatter install because PR https://github.com/deepset-ai/haystack/pull/3703 removed it as a dependency in Haystack.