### PR TITLE
bug: import TransformersQueryClassifier earlier

### DIFF
--- a/markdowns/14_Query_Classifier.md
+++ b/markdowns/14_Query_Classifier.md
@@ -299,6 +299,8 @@ The above example uses an `SklearnQueryClassifier`, but of course we can do prec
 
 
 ```python
+from haystack.nodes import TransformersQueryClassifier
+
 # Here we build the pipeline
 transformer_keyword_classifier = Pipeline()
 transformer_keyword_classifier.add_node(
@@ -398,8 +400,6 @@ The first label we provide corresponds to output_1, the second label to output_2
 
 
 ```python
-from haystack.nodes import TransformersQueryClassifier
-
 # Remember to compile a list with the exact model labels
 # The first label you provide corresponds to output_1, the second label to output_2, and so on.
 labels = ["LABEL_0", "LABEL_1", "LABEL_2"]

--- a/tutorials/14_Query_Classifier.ipynb
+++ b/tutorials/14_Query_Classifier.ipynb
@@ -549,6 +549,8 @@
    },
    "outputs": [],
    "source": [
+    'from haystack.nodes import TransformersQueryClassifier\n'
+    "\n",
     "# Here we build the pipeline\n",
     "transformer_keyword_classifier = Pipeline()\n",
     "transformer_keyword_classifier.add_node(\n",
@@ -689,8 +691,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from haystack.nodes import TransformersQueryClassifier\n",
-    "\n",
     "# Remember to compile a list with the exact model labels\n",
     "# The first label you provide corresponds to output_1, the second label to output_2, and so on.\n",
     "labels = [\"LABEL_0\", \"LABEL_1\", \"LABEL_2\"]\n",

--- a/tutorials/14_Query_Classifier.ipynb
+++ b/tutorials/14_Query_Classifier.ipynb
@@ -549,7 +549,7 @@
    },
    "outputs": [],
    "source": [
-    'from haystack.nodes import TransformersQueryClassifier\n'
+    "from haystack.nodes import TransformersQueryClassifier\n",
     "\n",
     "# Here we build the pipeline\n",
     "transformer_keyword_classifier = Pipeline()\n",


### PR DESCRIPTION
TransformersQueryClassifier was used before it was imported. Running the notebook failed for that reason.
This PR moves the import statement to an earlier cell preventing the error.

I tested this PR by running the changed tutorial on colab.