### PR TITLE
fix: pass the host to document store init

### DIFF
--- a/markdowns/14_Query_Classifier.md
+++ b/markdowns/14_Query_Classifier.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/14_Query_Classifier.ipynb
 toc: True
 title: "Query Classifier"
-last_updated: 2022-12-22
+last_updated: 2023-01-11
 level: "intermediate"
 weight: 80
 description: Classify incoming queries so that they can be routed to the nodes that are best at handling them.
@@ -225,7 +225,7 @@ time.sleep(30)
 host = os.environ.get("ELASTICSEARCH_HOST", "localhost")
 
 
-document_store = ElasticsearchDocumentStore()
+document_store = ElasticsearchDocumentStore(host=host)
 document_store.delete_documents()
 document_store.write_documents(got_docs)
 ```

--- a/tutorials/14_Query_Classifier.ipynb
+++ b/tutorials/14_Query_Classifier.ipynb
@@ -417,7 +417,7 @@
     "host = os.environ.get(\"ELASTICSEARCH_HOST\", \"localhost\")\n",
     "\n",
     "\n",
-    "document_store = ElasticsearchDocumentStore()\n",
+    "document_store = ElasticsearchDocumentStore(host=host)\n",
     "document_store.delete_documents()\n",
     "document_store.write_documents(got_docs)"
    ]
@@ -847,7 +847,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.6 (main, Aug 11 2022, 13:36:31) [Clang 13.1.6 (clang-1316.0.21.2.5)]"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Nightly builds are failing:  https://github.com/deepset-ai/haystack-tutorials/actions/workflows/nightly.yml

We don't pass the `host` param to the document store constructor, and the connection to Elasticsearch fails, fix in this PR.