### PR TITLE
chore: use images from this repo

### DIFF
--- a/.github/workflows/run_tutorials.yml
+++ b/.github/workflows/run_tutorials.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get changed files
         id: files
-        uses: tj-actions/changed-files@v34
+        uses: tj-actions/changed-files@v35
 
       - name: Convert notebooks to Python
         shell: bash

--- a/.github/workflows/run_tutorials.yml
+++ b/.github/workflows/run_tutorials.yml
@@ -34,6 +34,10 @@ jobs:
         with:
           fetch-depth: 2
 
+      # See https://github.com/actions/runner-images/issues/6775
+      - name: Change Owner of Container Working Directory
+        run: chown root:root .
+
       - name: Get changed files
         id: files
         uses: tj-actions/changed-files@v35

--- a/markdowns/02_Finetune_a_model_on_your_data.md
+++ b/markdowns/02_Finetune_a_model_on_your_data.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/02_Finetune_a_model_on_your_data.ipynb
 toc: True
 title: "Fine-Tuning a Model on Your Own Data"
-last_updated: 2023-02-02
+last_updated: 2023-02-03
 level: "intermediate"
 weight: 50
 description: Improve the performance of your Reader by performing fine-tuning.

--- a/markdowns/02_Finetune_a_model_on_your_data.md
+++ b/markdowns/02_Finetune_a_model_on_your_data.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/02_Finetune_a_model_on_your_data.ipynb
 toc: True
 title: "Fine-Tuning a Model on Your Own Data"
-last_updated: 2022-12-06
+last_updated: 2023-02-02
 level: "intermediate"
 weight: 50
 description: Improve the performance of your Reader by performing fine-tuning.
@@ -26,7 +26,7 @@ This tutorial shows you how to fine-tune a pretrained model on your own dataset.
 Make sure you enable the GPU runtime to experience decent speed in this tutorial.
 **Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
 
-<img src="https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg">
+<img src="https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg">
 
 
 ```python
@@ -72,7 +72,7 @@ There are two ways to generate training data
 
 1. **Annotation**: You can use the [annotation tool](https://haystack.deepset.ai/guides/annotation) to label your data, i.e. highlighting answers to your questions in a document. The tool supports structuring your workflow with organizations, projects, and users. The labels can be exported in SQuAD format that is compatible for training with Haystack.
 
-![Snapshot of the annotation tool](https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/annotation_tool.png)
+![Snapshot of the annotation tool](https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/annotation_tool.png)
 
 2. **Feedback**: For production systems, you can collect training data from direct user feedback via Haystack's [REST API interface](https://github.com/deepset-ai/haystack#rest-api). This includes a customizable user feedback API for providing feedback on the answer returned by the API. The API provides a feedback export endpoint to obtain the feedback data for fine-tuning your model further.
 

--- a/markdowns/04_FAQ_style_QA.md
+++ b/markdowns/04_FAQ_style_QA.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/04_FAQ_style_QA.ipynb
 toc: True
 title: "Utilizing Existing FAQs for Question Answering"
-last_updated: 2023-02-02
+last_updated: 2023-02-03
 level: "beginner"
 weight: 20
 description: Create a smarter way to answer new questions using your existing FAQ documents.

--- a/markdowns/04_FAQ_style_QA.md
+++ b/markdowns/04_FAQ_style_QA.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/04_FAQ_style_QA.ipynb
 toc: True
 title: "Utilizing Existing FAQs for Question Answering"
-last_updated: 2023-01-27
+last_updated: 2023-02-02
 level: "beginner"
 weight: 20
 description: Create a smarter way to answer new questions using your existing FAQ documents.
@@ -34,7 +34,7 @@ In some use cases, a combination of extractive QA and FAQ-style can also be an i
 Make sure you enable the GPU runtime to experience decent speed in this tutorial.
 **Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
 
-<img src="https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg">
+<img src="https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg">
 
 You can double check whether the GPU runtime is enabled with the following command:
 

--- a/markdowns/05_Evaluation.md
+++ b/markdowns/05_Evaluation.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/05_Evaluation.ipynb
 toc: True
 title: "Evaluation of a QA System"
-last_updated: 2023-02-02
+last_updated: 2023-02-03
 level: "advanced"
 weight: 100
 description: Learn how to evaluate the performance of individual nodes as well as entire pipelines.

--- a/markdowns/05_Evaluation.md
+++ b/markdowns/05_Evaluation.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/05_Evaluation.ipynb
 toc: True
 title: "Evaluation of a QA System"
-last_updated: 2022-11-24
+last_updated: 2023-02-02
 level: "advanced"
 weight: 100
 description: Learn how to evaluate the performance of individual nodes as well as entire pipelines.
@@ -23,7 +23,7 @@ The results of the evaluation can be saved as CSV files, which contain all the i
 Make sure you enable the GPU runtime to experience decent speed in this tutorial.
 **Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
 
-<img src="https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg">
+<img src="https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg">
 
 You can double check whether the GPU runtime is enabled with the following command:
 

--- a/markdowns/06_Better_Retrieval_via_Embedding_Retrieval.md
+++ b/markdowns/06_Better_Retrieval_via_Embedding_Retrieval.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/06_Better_Retrieval_via_Embedding_Retrieval.ipynb
 toc: True
 title: "Better Retrieval with Embedding Retrieval"
-last_updated: 2022-11-24
+last_updated: 2023-02-02
 level: "intermediate"
 weight: 55
 description: Use Transformer based dense Retrievers to improve your system’s performance.
@@ -60,7 +60,7 @@ Some models have been fine-tuned on massive Information Retrieval data and can b
 Make sure you enable the GPU runtime to experience decent speed in this tutorial.
 **Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
 
-<img src="https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg">
+<img src="https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg">
 
 You can double check whether the GPU runtime is enabled with the following command:
 

--- a/markdowns/06_Better_Retrieval_via_Embedding_Retrieval.md
+++ b/markdowns/06_Better_Retrieval_via_Embedding_Retrieval.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/06_Better_Retrieval_via_Embedding_Retrieval.ipynb
 toc: True
 title: "Better Retrieval with Embedding Retrieval"
-last_updated: 2023-02-02
+last_updated: 2023-02-03
 level: "intermediate"
 weight: 55
 description: Use Transformer based dense Retrievers to improve your system’s performance.

--- a/markdowns/07_RAG_Generator.md
+++ b/markdowns/07_RAG_Generator.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/07_RAG_Generator.ipynb
 toc: True
 title: "Generative QA with Retrieval-Augmented Generation"
-last_updated: 2023-02-02
+last_updated: 2023-02-03
 level: "intermediate"
 weight: 60
 description: Try out a generative model in place of the extractive Reader.

--- a/markdowns/07_RAG_Generator.md
+++ b/markdowns/07_RAG_Generator.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/07_RAG_Generator.ipynb
 toc: True
 title: "Generative QA with Retrieval-Augmented Generation"
-last_updated: 2022-11-24
+last_updated: 2023-02-02
 level: "intermediate"
 weight: 60
 description: Try out a generative model in place of the extractive Reader.
@@ -27,7 +27,7 @@ answer generator on a set of retrieved documents.
 Make sure you enable the GPU runtime to experience decent speed in this tutorial.
 **Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
 
-<img src="https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg">
+<img src="https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg">
 
 You can double check whether the GPU runtime is enabled with the following command:
 

--- a/markdowns/12_LFQA.md
+++ b/markdowns/12_LFQA.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/12_LFQA.ipynb
 toc: True
 title: "Generative QA with LFQA"
-last_updated: 2022-11-24
+last_updated: 2023-02-02
 level: "intermediate"
 weight: 70
 description: Try out a generative model in place of the extractive Reader.
@@ -22,7 +22,7 @@ Follow this tutorial to learn how to build and use a pipeline for Long-Form Ques
 Make sure you enable the GPU runtime to experience decent speed in this tutorial.  
 **Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
 
-<img src="https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg">
+<img src="https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg">
 
 You can double check whether the GPU runtime is enabled with the following command:
 

--- a/markdowns/12_LFQA.md
+++ b/markdowns/12_LFQA.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/12_LFQA.ipynb
 toc: True
 title: "Generative QA with LFQA"
-last_updated: 2023-02-02
+last_updated: 2023-02-03
 level: "intermediate"
 weight: 70
 description: Try out a generative model in place of the extractive Reader.

--- a/markdowns/13_Question_generation.md
+++ b/markdowns/13_Question_generation.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/13_Question_generation.ipynb
 toc: True
 title: "Question Generation"
-last_updated: 2023-02-02
+last_updated: 2023-02-03
 level: "intermediate"
 weight: 75
 description: Generate a set of questions that can be answered by a given Document.

--- a/markdowns/13_Question_generation.md
+++ b/markdowns/13_Question_generation.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/13_Question_generation.ipynb
 toc: True
 title: "Question Generation"
-last_updated: 2022-12-07
+last_updated: 2023-02-02
 level: "intermediate"
 weight: 75
 description: Generate a set of questions that can be answered by a given Document.
@@ -23,7 +23,7 @@ generate questions which the question generation model thinks can be answered by
 Make sure you enable the GPU runtime to experience decent speed in this tutorial.  
 **Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
 
-<img src="https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg">
+<img src="https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg">
 
 
 ```python

--- a/markdowns/14_Query_Classifier.md
+++ b/markdowns/14_Query_Classifier.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/14_Query_Classifier.ipynb
 toc: True
 title: "Query Classifier"
-last_updated: 2023-02-02
+last_updated: 2023-02-03
 level: "intermediate"
 weight: 80
 description: Classify incoming queries so that they can be routed to the nodes that are best at handling them.

--- a/markdowns/14_Query_Classifier.md
+++ b/markdowns/14_Query_Classifier.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/14_Query_Classifier.ipynb
 toc: True
 title: "Query Classifier"
-last_updated: 2023-01-11
+last_updated: 2023-02-02
 level: "intermediate"
 weight: 80
 description: Classify incoming queries so that they can be routed to the nodes that are best at handling them.
@@ -42,7 +42,7 @@ With all of that explanation out of the way, let's dive in!
 Make sure you enable the GPU runtime to experience decent speed in this tutorial.  
 **Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
 
-<img src="https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg">
+<img src="https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg">
 
 You can double check whether the GPU runtime is enabled with the following command:
 

--- a/markdowns/15_TableQA.md
+++ b/markdowns/15_TableQA.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/15_TableQA.ipynb
 toc: True
 title: "Open-Domain QA on Tables"
-last_updated: 2022-12-15
+last_updated: 2023-02-02
 level: "advanced"
 weight: 130
 description: Perform question answering on tabular data.
@@ -22,7 +22,7 @@ This tutorial shows you how to perform question-answering on tables using the `E
 Make sure you enable the GPU runtime to experience decent speed in this tutorial.
 **Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
 
-<img src="https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg">
+<img src="https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg">
 
 You can double check whether the GPU runtime is enabled with the following command:
 

--- a/markdowns/15_TableQA.md
+++ b/markdowns/15_TableQA.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/15_TableQA.ipynb
 toc: True
 title: "Open-Domain QA on Tables"
-last_updated: 2023-02-02
+last_updated: 2023-02-03
 level: "advanced"
 weight: 130
 description: Perform question answering on tabular data.

--- a/markdowns/17_Audio.md
+++ b/markdowns/17_Audio.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/17_Audio.ipynb
 toc: True
 title: "Make Your QA Pipelines Talk!"
-last_updated: 2022-12-08
+last_updated: 2023-02-02
 level: "intermediate"
 weight: 90
 description: Convert text Answers into speech.
@@ -26,7 +26,7 @@ In this tutorial, we're going to see how to use `AnswerToSpeech` to convert answ
 Make sure you enable the GPU runtime to experience decent speed in this tutorial.
 **Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
 
-<img src="https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg">
+<img src="https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg">
 
 You can double check whether the GPU runtime is enabled with the following command:
 

--- a/markdowns/17_Audio.md
+++ b/markdowns/17_Audio.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/17_Audio.ipynb
 toc: True
 title: "Make Your QA Pipelines Talk!"
-last_updated: 2023-02-02
+last_updated: 2023-02-03
 level: "intermediate"
 weight: 90
 description: Convert text Answers into speech.

--- a/markdowns/18_GPL.md
+++ b/markdowns/18_GPL.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/18_GPL.ipynb
 toc: True
 title: "Generative Pseudo Labeling for Domain Adaptation"
-last_updated: 2022-11-24
+last_updated: 2023-02-02
 level: "advanced"
 weight: 140
 description: Use a Retriever and a query generator to perform unsupervised domain adaptation.
@@ -49,7 +49,7 @@ If we search again with the updated model, we get the search results we would ex
 Make sure you enable the GPU runtime to experience decent speed in this tutorial.
 **Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
 
-<img src="https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg">
+<img src="https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg">
 
 
 

--- a/markdowns/18_GPL.md
+++ b/markdowns/18_GPL.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/18_GPL.ipynb
 toc: True
 title: "Generative Pseudo Labeling for Domain Adaptation"
-last_updated: 2023-02-02
+last_updated: 2023-02-03
 level: "advanced"
 weight: 140
 description: Use a Retriever and a query generator to perform unsupervised domain adaptation.

--- a/tutorials/02_Finetune_a_model_on_your_data.ipynb
+++ b/tutorials/02_Finetune_a_model_on_your_data.ipynb
@@ -14,6 +14,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false
@@ -25,7 +26,7 @@
     "Make sure you enable the GPU runtime to experience decent speed in this tutorial.\n",
     "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
     "\n",
-    "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg\">"
+    "<img src=\"https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg\">"
    ]
   },
   {
@@ -107,6 +108,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -117,7 +119,7 @@
     "\n",
     "1. **Annotation**: You can use the [annotation tool](https://haystack.deepset.ai/guides/annotation) to label your data, i.e. highlighting answers to your questions in a document. The tool supports structuring your workflow with organizations, projects, and users. The labels can be exported in SQuAD format that is compatible for training with Haystack.\n",
     "\n",
-    "![Snapshot of the annotation tool](https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/annotation_tool.png)\n",
+    "![Snapshot of the annotation tool](https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/annotation_tool.png)\n",
     "\n",
     "2. **Feedback**: For production systems, you can collect training data from direct user feedback via Haystack's [REST API interface](https://github.com/deepset-ai/haystack#rest-api). This includes a customizable user feedback API for providing feedback on the answer returned by the API. The API provides a feedback export endpoint to obtain the feedback data for fine-tuning your model further.\n",
     "\n",
@@ -309,7 +311,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.9"
+   "version": "3.9.6 (default, Aug  5 2022, 15:21:02) \n[Clang 14.0.0 (clang-1400.0.29.102)]"
   },
   "vscode": {
    "interpreter": {

--- a/tutorials/04_FAQ_style_QA.ipynb
+++ b/tutorials/04_FAQ_style_QA.ipynb
@@ -22,6 +22,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false
@@ -33,7 +34,7 @@
     "Make sure you enable the GPU runtime to experience decent speed in this tutorial.\n",
     "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
     "\n",
-    "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg\">\n",
+    "<img src=\"https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg\">\n",
     "\n",
     "You can double check whether the GPU runtime is enabled with the following command:"
    ]
@@ -372,7 +373,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.4 ('haystack-tutorials')",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -386,11 +387,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.6 (main, Aug 11 2022, 13:36:31) [Clang 13.1.6 (clang-1316.0.21.2.5)]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "1e4fa2e1c496b8379da88afac82c60055e1be33cd79040f849449f398c153e43"
+    "hash": "bda33b16be7e844498c7c2d368d72665b4f1d165582b9547ed22a0249a29ca2e"
    }
   }
  },

--- a/tutorials/05_Evaluation.ipynb
+++ b/tutorials/05_Evaluation.ipynb
@@ -13,6 +13,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "lEKOjCS5U7so",
@@ -27,7 +28,7 @@
     "Make sure you enable the GPU runtime to experience decent speed in this tutorial.\n",
     "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
     "\n",
-    "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg\">\n",
+    "<img src=\"https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg\">\n",
     "\n",
     "You can double check whether the GPU runtime is enabled with the following command:"
    ]

--- a/tutorials/06_Better_Retrieval_via_Embedding_Retrieval.ipynb
+++ b/tutorials/06_Better_Retrieval_via_Embedding_Retrieval.ipynb
@@ -49,6 +49,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "3K27Y5FbA6NV"
@@ -60,7 +61,7 @@
         "Make sure you enable the GPU runtime to experience decent speed in this tutorial.\n",
         "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
         "\n",
-        "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg\">\n",
+        "<img src=\"https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg\">\n",
         "\n",
         "You can double check whether the GPU runtime is enabled with the following command:"
       ]
@@ -450,7 +451,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.8.9"
+      "version": "3.9.6 (default, Aug  5 2022, 15:21:02) \n[Clang 14.0.0 (clang-1400.0.29.102)]"
     },
     "vscode": {
       "interpreter": {

--- a/tutorials/07_RAG_Generator.ipynb
+++ b/tutorials/07_RAG_Generator.ipynb
@@ -17,6 +17,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false
@@ -28,7 +29,7 @@
     "Make sure you enable the GPU runtime to experience decent speed in this tutorial.\n",
     "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
     "\n",
-    "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg\">\n",
+    "<img src=\"https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg\">\n",
     "\n",
     "You can double check whether the GPU runtime is enabled with the following command:"
    ]
@@ -365,7 +366,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.9 64-bit",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -379,11 +380,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "3.8.9"
+   "version": "3.10.6 (main, Aug 11 2022, 13:36:31) [Clang 13.1.6 (clang-1316.0.21.2.5)]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+    "hash": "bda33b16be7e844498c7c2d368d72665b4f1d165582b9547ed22a0249a29ca2e"
    }
   }
  },

--- a/tutorials/12_LFQA.ipynb
+++ b/tutorials/12_LFQA.ipynb
@@ -12,6 +12,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "3K27Y5FbA6NV"
@@ -23,7 +24,7 @@
     "Make sure you enable the GPU runtime to experience decent speed in this tutorial.  \n",
     "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
     "\n",
-    "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg\">\n",
+    "<img src=\"https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg\">\n",
     "\n",
     "You can double check whether the GPU runtime is enabled with the following command:"
    ]

--- a/tutorials/13_Question_generation.ipynb
+++ b/tutorials/13_Question_generation.ipynb
@@ -16,6 +16,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "yaaKv3_ZN-gb",
@@ -30,7 +31,7 @@
     "Make sure you enable the GPU runtime to experience decent speed in this tutorial.  \n",
     "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
     "\n",
-    "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg\">"
+    "<img src=\"https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg\">"
    ]
   },
   {

--- a/tutorials/14_Query_Classifier.ipynb
+++ b/tutorials/14_Query_Classifier.ipynb
@@ -35,6 +35,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "yaaKv3_ZN-gb",
@@ -49,7 +50,7 @@
     "Make sure you enable the GPU runtime to experience decent speed in this tutorial.  \n",
     "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
     "\n",
-    "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg\">\n",
+    "<img src=\"https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg\">\n",
     "\n",
     "You can double check whether the GPU runtime is enabled with the following command:"
    ]

--- a/tutorials/15_TableQA.ipynb
+++ b/tutorials/15_TableQA.ipynb
@@ -12,6 +12,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "vbR3bETlvi-3"
@@ -23,7 +24,7 @@
     "Make sure you enable the GPU runtime to experience decent speed in this tutorial.\n",
     "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
     "\n",
-    "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg\">\n",
+    "<img src=\"https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg\">\n",
     "\n",
     "You can double check whether the GPU runtime is enabled with the following command:"
    ]

--- a/tutorials/17_Audio.ipynb
+++ b/tutorials/17_Audio.ipynb
@@ -16,6 +16,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
@@ -28,7 +29,7 @@
     "Make sure you enable the GPU runtime to experience decent speed in this tutorial.\n",
     "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
     "\n",
-    "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg\">\n",
+    "<img src=\"https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg\">\n",
     "\n",
     "You can double check whether the GPU runtime is enabled with the following command:"
    ]

--- a/tutorials/18_GPL.ipynb
+++ b/tutorials/18_GPL.ipynb
@@ -46,7 +46,7 @@
     "Make sure you enable the GPU runtime to experience decent speed in this tutorial.\n",
     "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
     "\n",
-    "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/main/docs/img/colab_gpu_runtime.jpg\">\n"
+    "<img src=\"https://github.com/deepset-ai/haystack-tutorials/raw/main/tutorials/img/colab_gpu_runtime.jpg\">\n"
    ]
   },
   {


### PR DESCRIPTION
Tutorials (hence markdowns, hence the website) are hard-linking images from Haystack repo - changes in Haystack might be disruptive for tutorials and we wouldn't notice.

This PR uses images that are already in this repo, lowering the chances something breaks and we don't notice.