### PR TITLE
fix: fix typo in tutorial 12

### DIFF
--- a/markdowns/12_LFQA.md
+++ b/markdowns/12_LFQA.md
@@ -3,7 +3,7 @@ layout: tutorial
 colab: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/12_LFQA.ipynb
 toc: True
 title: "Generative QA with LFQA"
-last_updated: 2023-02-03
+last_updated: 2023-02-13
 level: "intermediate"
 weight: 70
 description: Try out a generative model in place of the extractive Reader.
@@ -14,7 +14,7 @@ download: "/downloads/12_LFQA.ipynb"
     
 
 
-Follow this tutorial to learn how to build and use a pipeline for Long-Form Question Answering (LFQA). LFQA is a variety of the generative question answering task. LFQA systems query large document stores for relevant information and then use this information to generate accurate, multi-sentence answers. In a regular question answering system, the retrieved documents related to the query (context passages) act as source tokens for extracted answers. In an LFQS system, context passages provide the context the system uses to generate original, abstractive, long-form answers.
+Follow this tutorial to learn how to build and use a pipeline for Long-Form Question Answering (LFQA). LFQA is a variety of the generative question answering task. LFQA systems query large document stores for relevant information and then use this information to generate accurate, multi-sentence answers. In a regular question answering system, the retrieved documents related to the query (context passages) act as source tokens for extracted answers. In an LFQA system, context passages provide the context the system uses to generate original, abstractive, long-form answers.
 
 ### Prepare environment
 

--- a/tutorials/12_LFQA.ipynb
+++ b/tutorials/12_LFQA.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Long-Form Question Answering\n",
     "\n",
-    "Follow this tutorial to learn how to build and use a pipeline for Long-Form Question Answering (LFQA). LFQA is a variety of the generative question answering task. LFQA systems query large document stores for relevant information and then use this information to generate accurate, multi-sentence answers. In a regular question answering system, the retrieved documents related to the query (context passages) act as source tokens for extracted answers. In an LFQS system, context passages provide the context the system uses to generate original, abstractive, long-form answers."
+    "Follow this tutorial to learn how to build and use a pipeline for Long-Form Question Answering (LFQA). LFQA is a variety of the generative question answering task. LFQA systems query large document stores for relevant information and then use this information to generate accurate, multi-sentence answers. In a regular question answering system, the retrieved documents related to the query (context passages) act as source tokens for extracted answers. In an LFQA system, context passages provide the context the system uses to generate original, abstractive, long-form answers."
    ]
   },
   {


### PR DESCRIPTION
There was a typo spelling LFQA as LFQS. I changed it to LFQA.