### PR TITLE
remove automatically inferred model_format param

### DIFF
--- a/tutorials/06_Better_Retrieval_via_Embedding_Retrieval.ipynb
+++ b/tutorials/06_Better_Retrieval_via_Embedding_Retrieval.ipynb
@@ -293,7 +293,6 @@
         "retriever = EmbeddingRetriever(\n",
         "    document_store=document_store,\n",
         "    embedding_model=\"sentence-transformers/multi-qa-mpnet-base-dot-v1\",\n",
-        "    model_format=\"sentence_transformers\",\n",
         ")\n",
         "# Important:\n",
         "# Now that we initialized the Retriever, we need to call update_embeddings() to iterate over all\n",


### PR DESCRIPTION
This PR removes the model_format param from the EmbeddingRetriever init because the parameter is not required anymore. The model format is automatically inferred.