### PR TITLE
[Tutorial 8 and 16] Remove `xpdf` installation

### DIFF
--- a/tutorials/08_Preprocessing.ipynb
+++ b/tutorials/08_Preprocessing.ipynb
@@ -63,15 +63,7 @@
     "%%bash\n",
     "\n",
     "pip install --upgrade pip\n",
-    "pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,ocr]\n",
-    "\n",
-    "# For Colab/linux based machines:\n",
-    "wget https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz\n",
-    "tar -xvf xpdf-tools-linux-4.04.tar.gz && sudo cp xpdf-tools-linux-4.04/bin64/pdftotext /usr/local/bin\n",
-    "\n",
-    "# For macOS machines:\n",
-    "# wget https://dl.xpdfreader.com/xpdf-tools-mac-4.03.tar.gz\n",
-    "# tar -xvf xpdf-tools-mac-4.03.tar.gz && sudo cp xpdf-tools-mac-4.03/bin64/pdftotext /usr/local/bin"
+    "pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,ocr]"
    ]
   },
   {

--- a/tutorials/08_Preprocessing.ipynb
+++ b/tutorials/08_Preprocessing.ipynb
@@ -63,7 +63,7 @@
     "%%bash\n",
     "\n",
     "pip install --upgrade pip\n",
-    "pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,ocr]"
+    "pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,ocr,pdf]"
    ]
   },
   {

--- a/tutorials/16_Document_Classifier_at_Index_Time.ipynb
+++ b/tutorials/16_Document_Classifier_at_Index_Time.ipynb
@@ -46,7 +46,7 @@
     "\n",
     "# Install the latest main of Haystack\n",
     "pip install --upgrade pip\n",
-    "pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,ocr]\n",
+    "pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,ocr,pdf]\n",
     "\n",
     "apt install libgraphviz-dev\n",
     "pip install pygraphviz"

--- a/tutorials/16_Document_Classifier_at_Index_Time.ipynb
+++ b/tutorials/16_Document_Classifier_at_Index_Time.ipynb
@@ -48,9 +48,6 @@
     "pip install --upgrade pip\n",
     "pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,ocr]\n",
     "\n",
-    "wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz\n",
-    "tar -xvf xpdf-tools-linux-4.04.tar.gz && sudo cp xpdf-tools-linux-4.04/bin64/pdftotext /usr/local/bin\n",
-    "\n",
     "apt install libgraphviz-dev\n",
     "pip install pygraphviz"
    ]


### PR DESCRIPTION
Address #133.

As described in #133 I removed `xpdf` installation commands from tutorials 8 and 16. 
I also modified the haystack installation command adding `pdf` support - required for `PDFToTextConverter`.