### PR TITLE
Temporary version fix for the tutorial 5

### DIFF
--- a/.github/workflows/run_tutorials.yml
+++ b/.github/workflows/run_tutorials.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           skiplist=(
               "tutorials/02_Finetune_a_model_on_your_data.ipynb"
+              "tutorials/05_Evaluation.ipynb"
               "tutorials/09_DPR_training.ipynb"
               "tutorials/13_Question_generation.ipynb"
               "tutorials/14_Query_Classifier.ipynb"

--- a/tutorials/05_Evaluation.ipynb
+++ b/tutorials/05_Evaluation.ipynb
@@ -85,7 +85,7 @@
     "%%bash\n",
     "\n",
     "pip install --upgrade pip\n",
-    "pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]"
+    "pip install farm-haystack==1.13.0"
    ]
   },
   {


### PR DESCRIPTION
Related to #121 
Something is broken with Haystack starting from 1.14. This is a temporary fix to have a working tutorial. 
It will be solved with https://github.com/deepset-ai/haystack/issues/4411.