### PR TITLE
Fix dc_sync.yml never getting triggered

### DIFF
--- a/.github/workflows/dc_sync.yml
+++ b/.github/workflows/dc_sync.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - "./tutorials/[0-9]*.ipynb"
+      - "tutorials/[0-9]*.ipynb"
 
 jobs:
   get-tutorials:


### PR DESCRIPTION
Tutorials are not being synced with deepset Cloud as the workflow is never starting.

The `paths` filter is wrong, this PR fixes it.