### PR TITLE
Update tutorials to use the `metrics` extra where necessary

### DIFF
--- a/tutorials/05_Evaluation.ipynb
+++ b/tutorials/05_Evaluation.ipynb
@@ -85,7 +85,7 @@
     "%%bash\n",
     "\n",
     "pip install --upgrade pip\n",
-    "pip install farm-haystack[colab]"
+    "pip install farm-haystack[colab,metrics]"
    ]
   },
   {


### PR DESCRIPTION
https://github.com/deepset-ai/haystack/pull/4457 moves a few dependencies out of the core list, so some tutorials need to be adapted to install them.