### PR TITLE
Add requirements installation step in dc_sync.yml

### DIFF
--- a/.github/workflows/dc_sync.yml
+++ b/.github/workflows/dc_sync.yml
@@ -47,6 +47,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install requirements
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+
       - name: Generate file to upload
         id: file-generator
         run: |
@@ -75,7 +84,7 @@ jobs:
       # This step is really important as when we remove a tutorial
       # notebook we also want to remove the relative file from
       # deepset Cloud, but since the remote file will have a .txt
-      # extension we must first the full file name with this step.
+      # extension we must first generate the full file name with this step.
       - name: Get file with correct extension
         id: extension-changer
         run: |


### PR DESCRIPTION
`dc_sync.yml` workflow is currently failing when uploading modified tutorials as we're not installing `scripts/generate_txt.py` dependencies in the `modified` job.

This PR adds two steps to setup Python and install `requirements.txt`.


Example failure: https://github.com/deepset-ai/haystack-tutorials/actions/runs/4701510715/jobs/8337623213