### PR TITLE
Add `metrics` extra to Tutorial 5

### DIFF
--- a/tutorials/05_Evaluation.ipynb
+++ b/tutorials/05_Evaluation.ipynb
@@ -54,7 +54,7 @@
     "%%bash\n",
     "\n",
     "pip install --upgrade pip\n",
-    "pip install farm-haystack[colab,preprocessing,elasticsearch]"
+    "pip install farm-haystack[colab,preprocessing,elasticsearch,metrics]"
    ]
   },
   {


### PR DESCRIPTION
Since v1.16, we need to install the `metrics` extra in order to do evaluation. This PR adds the `metrics` extra to Tutorial 5.