### PR TITLE
Change how metadata is handled in dc_sync.yml

### DIFF
--- a/.github/workflows/dc_sync.yml
+++ b/.github/workflows/dc_sync.yml
@@ -62,7 +62,7 @@ jobs:
           FILE="$(basename ${{ matrix.file }} .ipynb).txt"
           echo "file=text/$FILE" >> "$GITHUB_OUTPUT"
           METADATA="$(python scripts/generate_txt.py --print-metadata --notebooks ${{ matrix.file }})"
-          echo "metadata=$METADATA" >> "$GITHUB_OUTPUT"
+          echo "$METADATA" >> "text/metadata.yml"
 
       - name: Upload tutorial to deepset Cloud
         uses: silvanocerza/deepset-cloud-file-uploader@v1
@@ -71,7 +71,7 @@ jobs:
           workspace-name: ${{ secrets.DEEPSET_CLOUD_WORKSPACE }}
           file: ${{ steps.file-generator.outputs.file }}
           write-mode: OVERWRITE
-          metadata: ${{ steps.file-generator.outputs.metadata }}
+          meta-file: text/metadata.yml
 
   deleted:
     needs: get-tutorials


### PR DESCRIPTION
I changed [deepset-cloud-file-uploader](https://github.com/silvanocerza/deepset-cloud-file-uploader) action to accept a new input, `meta-file`, so metadata can be specified using a file instead of a string.

This should fix this kind of error:
https://github.com/deepset-ai/haystack-tutorials/actions/runs/4831970664/jobs/8610138333