### PR TITLE
Add missing tutorial extra dependency

### DIFF
--- a/tutorials/15_TableQA.ipynb
+++ b/tutorials/15_TableQA.ipynb
@@ -43,7 +43,7 @@
     "%%bash\n",
     "\n",
     "pip install --upgrade pip\n",
-    "pip install farm-haystack[colab,elasticsearch]\n",
+    "pip install farm-haystack[colab,elasticsearch,metrics]\n",
     "\n",
     "# Install pygraphviz for visualization of Pipelines\n",
     "apt install libgraphviz-dev\n",


### PR DESCRIPTION
Tutorial 15 is currently missing the `metrics` extra, that makes the evaluation part of the tutorial to fail.
See attached screenshot of the error. This PR will fix the failure.

![Screenshot 2023-05-02 at 11-39-49 Google Colaboratory](https://user-images.githubusercontent.com/3314350/235633145-1eb7f9ae-f2ed-49bc-95f7-cee0ec7c9d77.png)
