### PR TITLE
Fix dc sync matrix failure

### DIFF
--- a/.github/workflows/dc_sync.yml
+++ b/.github/workflows/dc_sync.yml
@@ -13,8 +13,6 @@ jobs:
     outputs:
       modified-matrix: ${{ steps.create_matrix.outputs.modified-matrix }}
       deleted-matrix: ${{ steps.create_matrix.outputs.deleted-matrix }}
-      any-changed: ${{ steps.files.outputs.any_changed }}
-      any-deleted: ${{ steps.files.outputs.any_deleted }}
 
     steps:
       - name: Checkout
@@ -33,15 +31,16 @@ jobs:
       - name: Create matrixes
         id: create_matrix
         run: |
-          echo "modified-matrix={\"file\": ${{ steps.files.outputs.all_changed_files }}}" >> "$GITHUB_OUTPUT"
-          echo "deleted-matrix={\"file\": ${{ steps.files.outputs.deleted_files }}}" >> "$GITHUB_OUTPUT"
+          echo "modified-matrix=${{ steps.files.outputs.all_changed_files }}" >> "$GITHUB_OUTPUT"
+          echo "deleted-matrix=${{ steps.files.outputs.deleted_files }}" >> "$GITHUB_OUTPUT"
 
   modified:
     needs: get-tutorials
-    if: needs.get-tutorials.outputs.any-changed
+    if: ${{ needs.get-tutorials.outputs.modified-matrix != '[]' && needs.get-tutorials.outputs.modified-matrix != '' }}
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJSON(needs.get-tutorials.outputs.modified-matrix) }}
+      matrix:
+        file: ${{ fromJSON(needs.get-tutorials.outputs.modified-matrix) }}
 
     steps:
       - name: Checkout
@@ -76,10 +75,11 @@ jobs:
 
   deleted:
     needs: get-tutorials
-    if: needs.get-tutorials.outputs.any-deleted
+    if: ${{ needs.get-tutorials.outputs.deleted-matrix != '[]' && needs.get-tutorials.outputs.deleted-matrix != '' }}
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJSON(needs.get-tutorials.outputs.deleted-matrix) }}
+      matrix:
+        file: ${{ fromJSON(needs.get-tutorials.outputs.deleted-matrix) }}
 
     steps:
       # This step is really important as when we remove a tutorial


### PR DESCRIPTION
Depends on #183.

Currently `dc_sync.yml` is still marked as failed when a matrix is skipped cause there are no files to process for that job.

See [this run](https://github.com/deepset-ai/haystack-tutorials/actions/runs/4859928548) as example. The jobs than ran were succesfull but the workflow run was still marked as failed cause of the error reported below.
![image](https://user-images.githubusercontent.com/3314350/235887319-7e4182bd-fa09-4212-90c8-b226facc469b.png)

This PR changes how a job is skipped so that the workflow is not marked as failed anymore, even a matrix job didn't run.
See [this example run](https://github.com/silvanocerza/nodenode/actions/runs/4870598449) on a repo that I used for testing workflows. Notice how the behaviour of [the workflow](https://github.com/silvanocerza/nodenode/actions/runs/4870598449/workflow) in the test repo is pretty similar to `dc_sync.yml`.

![Screenshot 2023-05-03 at 12 04 52](https://user-images.githubusercontent.com/3314350/235887721-2099190f-b426-4b10-b09d-e7b03d19321f.png)
