### PR TITLE
Change full_dc_sync.yml workflow name

### DIFF
--- a/.github/workflows/full_dc_sync.yml
+++ b/.github/workflows/full_dc_sync.yml
@@ -1,4 +1,4 @@
-name: Sync tutorial with dC workspace
+name: Sync all tutorials with dC workspace
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Currently both `full_dc_sync.yml` and `dc_sync.yml` have the same name, this is confusing.
This PR changes the `full_dc_sync.yml` workflow name to `Sync all tutorials with dC workspace` to differentiate them.

![image](https://user-images.githubusercontent.com/3314350/235892908-95fc9cc9-613f-4640-9202-7a3805e6da3f.png)
