### PR TITLE
Update the Tutorial 2

### DIFF
--- a/tutorials/02_Finetune_a_model_on_your_data.ipynb
+++ b/tutorials/02_Finetune_a_model_on_your_data.ipynb
@@ -47,7 +47,7 @@
     "%%bash\n",
     "\n",
     "pip install --upgrade pip\n",
-    "pip install farm-haystack[colab]==1.16.1"
+    "pip install farm-haystack[colab, inference]"
    ]
   },
   {


### PR DESCRIPTION
Fixes #202.

Since https://github.com/deepset-ai/haystack/issues/5114 has been fixed, we can use the latest version of Haystack in this tutorial.
I've also added the required `inference` dependency group.
