### PR TITLE
fix: Remove whitespace from pip install extras in tutorial 2

### DIFF
--- a/tutorials/02_Finetune_a_model_on_your_data.ipynb
+++ b/tutorials/02_Finetune_a_model_on_your_data.ipynb
@@ -47,7 +47,7 @@
     "%%bash\n",
     "\n",
     "pip install --upgrade pip\n",
-    "pip install farm-haystack[colab, inference]"
+    "pip install farm-haystack[colab,inference]"
    ]
   },
   {


### PR DESCRIPTION
This PR removes the whitespace from pip install extras in tutorial 2: `pip install farm-haystack[colab, inference]`.
With the whitespace installation fails and the error message doesn't point out the problem. After removing the whitespace the installation works without any issues.

I checked that all other tutorials don't have any whitespace in the pip install extras. ✅ 

To reproduce the error: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/02_Finetune_a_model_on_your_data.ipynb

To try the fix: https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/tutorial-2-fix-installation/tutorials/02_Finetune_a_model_on_your_data.ipynb