### PR TITLE
Update tutorials and emphasize RAG in tutorial 22

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -61,12 +61,12 @@ aliases = ["embedding-retrieval"]
 created_at = 2022-03-08
 
 [[tutorial]]
-title = "Generative QA with Retrieval-Augmented Generation"
+title = "Generative QA with RAGenerator"
 description = "Try out a generative model in place of the extractive Reader."
 level = "intermediate"
 weight = 60
 notebook = "07_RAG_Generator.ipynb"
-aliases = ["retrieval-augmented-generation"]
+aliases = []
 created_at = 2021-08-12
 haystack_version = "1.17.2"
 
@@ -109,7 +109,7 @@ aliases = ["pipelines"]
 created_at = 2021-08-12
 
 [[tutorial]]
-title = "Generative QA with LFQA"
+title = "Generative QA with Seq2SeqGenerator"
 description = "Try out a generative model in place of the extractive Reader."
 level = "intermediate"
 weight = 70
@@ -216,12 +216,12 @@ completion_time = "10 min"
 created_at = 2023-03-27
 
 [[tutorial]]
-title = "Creating a Generative QA Pipeline with PromptNode"
-description = "Use a large language model in your search system through PromptNode and Shaper."
+title = "Creating a Generative QA Pipeline with Retrieval-Augmentation"
+description = "Use a large language model in your search system through PromptNode"
 level = "intermediate"
 weight = 61
 notebook = "22_Pipeline_with_PromptNode.ipynb"
-aliases = ["pipeline-with-promptnode"]
+aliases = ["pipeline-with-promptnode", "retrieval-augmented-generation"]
 completion_time = "15 min"
 created_at = 2023-03-13
 

--- a/tutorials/07_RAG_Generator.ipynb
+++ b/tutorials/07_RAG_Generator.ipynb
@@ -7,7 +7,7 @@
     "collapsed": false
    },
    "source": [
-    "# Generative QA with \"Retrieval-Augmented Generation\""
+    "# Generative QA with RAGenerator"
    ]
   },
   {
@@ -15,7 +15,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> As of version 1.16, `RAGenerator` has been deprecated in Haystack and completely removed from Haystack as of v1.18. We recommend following the tutorial on [Creating a Generative QA Pipeline with PromptNode](https://haystack.deepset.ai/tutorials/22_pipeline_with_promptnode) instead. For more details about this deprecation, check out [our announcement](https://github.com/deepset-ai/haystack/discussions/4816) on Github."
+    "> As of version 1.16, `RAGenerator` has been deprecated in Haystack and completely removed from Haystack as of v1.18. We recommend following the tutorial on [Creating a Generative QA Pipeline with Retrieval-Augmentation](https://haystack.deepset.ai/tutorials/22_pipeline_with_promptnode) instead. For more details about this deprecation, check out [our announcement](https://github.com/deepset-ai/haystack/discussions/4816) on Github."
    ]
   },
   {

--- a/tutorials/12_LFQA.ipynb
+++ b/tutorials/12_LFQA.ipynb
@@ -7,7 +7,7 @@
     "id": "bEH-CRbeA6NU"
    },
    "source": [
-    "# Long-Form Question Answering"
+    "# Generative QA with Seq2SeqGenerator"
    ]
   },
   {
@@ -15,7 +15,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> As of version 1.16, `Seq2SeqGenerator` has been deprecated in Haystack and completely removed from Haystack as of v1.18. We recommend following the tutorial on [Creating a Generative QA Pipeline with PromptNode](https://haystack.deepset.ai/tutorials/22_pipeline_with_promptnode) instead. For more details about this deprecation, check out [our announcement](https://github.com/deepset-ai/haystack/discussions/4816) on Github."
+    "> As of version 1.16, `Seq2SeqGenerator` has been deprecated in Haystack and completely removed from Haystack as of v1.18. We recommend following the tutorial on [Creating a Generative QA Pipeline with Retrieval-Augmentation](https://haystack.deepset.ai/tutorials/22_pipeline_with_promptnode) instead. For more details about this deprecation, check out [our announcement](https://github.com/deepset-ai/haystack/discussions/4816) on Github."
    ]
   },
   {

--- a/tutorials/22_Pipeline_with_PromptNode.ipynb
+++ b/tutorials/22_Pipeline_with_PromptNode.ipynb
@@ -7,12 +7,12 @@
     "id": "2OvkPji9O-qX"
    },
    "source": [
-    "# Tutorial: Creating a Generative QA Pipeline with PromptNode\n",
+    "# Tutorial: Creating a Generative QA Pipeline with Retrieval-Augmentation\n",
     "\n",
     "- **Level**: Intermediate\n",
     "- **Time to complete**: 15 minutes\n",
     "- **Nodes Used**: `InMemoryDocumentStore`, `BM25Retriever`, `PromptNode`, `PromptTemplate`\n",
-    "- **Goal**: After completing this tutorial, you'll have created a generative question answering search system that uses a large language model through PromptNode with the new PromptTemplate structure."
+    "- **Goal**: After completing this tutorial, you'll have created a generative question answering search system that uses a large language model through PromptNode with PromptTemplate."
    ]
   },
   {
@@ -24,9 +24,9 @@
    "source": [
     "## Overview\n",
     "\n",
-    "Learn how to build a generative question answering pipeline using the power of LLMs with PromptNode. In this tutorial, we'll use the Wikipedia pages of [Seven Wonders of the Ancient World](https://en.wikipedia.org/wiki/Wonders_of_the_World) as Documents, but you can replace them with any text you want.\n",
+    "Learn how to build a generative question answering pipeline using the power of LLMs with PromptNode. In this generative pipeline, BM25Retriever gets the related Documents, and PromptNode generates the answer using the retrieval augmented generation ([RAG](https://www.deepset.ai/blog/llms-retrieval-augmentation)) approach. In this tutorial, we'll use the Wikipedia pages of [Seven Wonders of the Ancient World](https://en.wikipedia.org/wiki/Wonders_of_the_World) as Documents, but you can replace them with any text you want. \n",
     "\n",
-    "This tutorial introduces you to the new PrompTemplate structure and explains how to use the new PrompTemplate to integrate PromptNode into a pipeline."
+    "This tutorial introduces you to the PrompTemplate structure and explains how to use the new PrompTemplate to integrate PromptNode into a pipeline."
    ]
   },
   {
@@ -218,6 +218,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "6CEuQpB7O-qb"
@@ -240,7 +241,7 @@
    "source": [
     "from haystack.nodes import PromptNode, PromptTemplate, AnswerParser\n",
     "\n",
-    "lfqa_prompt = PromptTemplate(\n",
+    "rag_prompt = PromptTemplate(\n",
     "    prompt=\"\"\"Synthesize a comprehensive answer from the following text for the given question.\n",
     "                             Provide a clear and concise response that summarizes the key points and information presented in the text.\n",
     "                             Your answer should be in your own words and be no longer than 50 words.\n",
@@ -248,7 +249,7 @@
     "    output_parser=AnswerParser(),\n",
     ")\n",
     "\n",
-    "prompt_node = PromptNode(model_name_or_path=\"google/flan-t5-large\", default_prompt_template=lfqa_prompt)"
+    "prompt_node = PromptNode(model_name_or_path=\"google/flan-t5-large\", default_prompt_template=rag_prompt)"
    ]
   },
   {
@@ -322,7 +323,7 @@
    },
    "outputs": [],
    "source": [
-    "output = pipe.run(query=\"How does Rhodes Statue look like?\")\n",
+    "output = pipe.run(query=\"What does Rhodes Statue look like?\")\n",
     "\n",
     "print(output[\"answers\"][0].answer)"
    ]
@@ -348,7 +349,7 @@
     "examples = [\n",
     "    \"Where is Gardens of Babylon?\",\n",
     "    \"Why did people build Great Pyramid of Giza?\",\n",
-    "    \"How does Rhodes Statue look like?\",\n",
+    "    \"What does Rhodes Statue look like?\",\n",
     "    \"Why did people visit the Temple of Artemis?\",\n",
     "    \"What is the importance of Colossus of Rhodes?\",\n",
     "    \"What happened to the Tomb of Mausolus?\",\n",

--- a/tutorials/25_Customizing_Agent.ipynb
+++ b/tutorials/25_Customizing_Agent.ipynb
@@ -258,7 +258,7 @@
     "\n",
     "A generative QA pipeline consists of a PromptNode and a Retriever. In this pipeline, Retriever gets the related Documents, and PromptNode generates the answer using the retrieval augmented generation ([RAG](https://www.deepset.ai/blog/llms-retrieval-augmentation)) approach.\n",
     "\n",
-    "> To learn about the details of a generative pipeline with RAG, check out [Tutorial: Creating a Generative QA Pipeline with PromptNode](https://haystack.deepset.ai/tutorials/22_pipeline_with_promptnode)."
+    "> To learn about the details of a generative pipeline with RAG, check out [Tutorial: Creating a Generative QA Pipeline with Retrieval-Augmentation](https://haystack.deepset.ai/tutorials/22_pipeline_with_promptnode)."
    ]
   },
   {
@@ -317,7 +317,7 @@
    "source": [
     "from haystack.utils import print_answers\n",
     "\n",
-    "response = generative_pipeline.run(\"How does Rhodes Statue look like?\")\n",
+    "response = generative_pipeline.run(\"What does Rhodes Statue look like?\")\n",
     "print_answers(response, details=\"minimum\")"
    ]
   },
@@ -343,7 +343,7 @@
    },
    "outputs": [],
    "source": [
-    "response = generative_pipeline.run(\"How does Taylor Swift look like?\")\n",
+    "response = generative_pipeline.run(\"What does Taylor Swift look like?\")\n",
     "print_answers(response, details=\"minimum\")"
    ]
   },


### PR DESCRIPTION
Fixes #228 
### Changes
* Update the names of tutorial 7 and tutorial 12 - Emphasize the generator component, not mention RAG
* Add "Retrieval-Augmentation" to the tutorial 22 title
    * Change the name in tutorial 7, 12, 25 where this tutorial was mentioned 
* Add a section to the overview of tutorial 22 about RAG 
    * This change is important to be searchable 
* Change the redirect for "retrieval-augmented-generation" to tutorial 22 - Not sure if this is okay from the SEO perspective
### Out of Context
* Replace "How" with "what" in examples queries 