### PR TITLE
Tutorial 3: improve Elasticsearch start part

### DIFF
--- a/tutorials/03_Scalable_QA_System.ipynb
+++ b/tutorials/03_Scalable_QA_System.ipynb
@@ -157,7 +157,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you are working in an environment where Docker is available, you can also start Elasticsearch using Docker. You can do this manually, or using our [`launch_es()`](https://docs.haystack.deepset.ai/reference/utils-api#module-doc_store) utility function."
+    "If Docker is available in your environment (Colab notebooks do not support Docker), you can also start Elasticsearch using Docker. You can do this manually, or using our [`launch_es()`](https://docs.haystack.deepset.ai/reference/utils-api#module-doc_store) utility function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# from haystack.utils import launch_es\n",
+    "\n",
+    "# launch_es()"
    ]
   },
   {
@@ -185,17 +196,6 @@
    "metadata": {},
    "source": [
     "4. Initialize the ElasticsearchDocumentStore:\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from haystack.utils import launch_es\n",
-    "\n",
-    "launch_es()"
    ]
   },
   {


### PR DESCRIPTION
Docker is not available in Colab, so this option to start Elasticsearch is not viable when running in Colab.

I reordered the content a bit and commented the code to start Elasticsearch using Docker.