### PR TITLE
Remove hidden tutorials from the sitemap

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -71,6 +71,7 @@ aliases = []
 created_at = 2021-08-12
 haystack_version = "1.17.2"
 hidden = true
+sitemap_exclude = true
 
 [[tutorial]]
 title = "Preprocessing Your Documents"
@@ -101,6 +102,7 @@ aliases = ["knowledge-graph"]
 created_at = 2021-08-12
 haystack_version = "1.16.1"
 hidden = true
+sitemap_exclude = true
 
 [[tutorial]]
 title = "How to Use Pipelines"
@@ -121,6 +123,7 @@ aliases = ["lfqa"]
 created_at = 2021-08-12
 haystack_version = "1.17.2"
 hidden = true
+sitemap_exclude = true
 
 [[tutorial]]
 title = "Question Generation"

--- a/scripts/generate_markdowns.py
+++ b/scripts/generate_markdowns.py
@@ -25,6 +25,7 @@ layout: {config["layout"]}
 featured: {tutorial.get("featured", False)}
 haystack_version: "{tutorial.get("haystack_version", "latest")}"
 hidden: {tutorial.get("hidden", False)}
+sitemap_exclude: {tutorial.get("sitemap_exclude", False)}
 colab: {tutorial.get("colab", f'{config["colab"]}{tutorial["notebook"]}')}
 toc: {config["toc"]}
 title: "{tutorial["title"]}"


### PR DESCRIPTION
Currently, hiding a tutorial is controlled by two parameters: `hidden` and `sitemap_exclude`. 
* `hidden` makes sure that this tutorial is not visible to users on the website and not searchable on the website
* `sitemap_exclude` removed the tutorials from the sitemap to prevent indexing by search engines such as Google. 

In the future, we can merge these two fields and control the visibility of tutorials with one param that might be `sitemap_exclude`