### PR TITLE
Little fix in tutorial 2

### DIFF
--- a/tutorials/02_Finetune_a_model_on_your_data.ipynb
+++ b/tutorials/02_Finetune_a_model_on_your_data.ipynb
@@ -121,7 +121,7 @@
    "source": [
     "from haystack.nodes import FARMReader\n",
     "\n",
-    "reader = FARMReader(model_name_or_path=\"distilbert-base-uncased-distilled-squad\", use_gpu=True, devices=[\"mps\"])"
+    "reader = FARMReader(model_name_or_path=\"distilbert-base-uncased-distilled-squad\", use_gpu=True)"
    ]
   },
   {


### PR DESCRIPTION
I have verified that `devices=["mps"]` makes this tutorial fail in Colab with the error:
`RuntimeError: PyTorch is not linked with support for mps devices`

So I'm removing this parameter.

_I also noticed that we are not testing this tutorial nightly. Do you know why?_