### PR TITLE
tutorial 9: add missing metrics installation group

### DIFF
--- a/tutorials/09_DPR_training.ipynb
+++ b/tutorials/09_DPR_training.ipynb
@@ -40,7 +40,7 @@
     "%%bash\n",
     "\n",
     "pip install --upgrade pip\n",
-    "pip install farm-haystack[colab,inference]"
+    "pip install farm-haystack[colab,inference,metrics]"
    ]
   },
   {


### PR DESCRIPTION
While running this tutorial,
after an hour training, it failed because `seqeval` library ([in `metrics` installation group](https://github.com/deepset-ai/haystack/blob/4ef2a680bbfa10ddd770a26966d44d661d2ffd9c/pyproject.toml#L190)) was missing.

I'm adding this group to installation.