### PR TITLE
tutorial 24: replace oasst-sft-1-pythia-12b with zephyr-7b-beta

### DIFF
--- a/tutorials/24_Building_Chat_App.ipynb
+++ b/tutorials/24_Building_Chat_App.ipynb
@@ -143,7 +143,7 @@
       "source": [
         "### 2) Create a PromptNode\n",
         "\n",
-        "You'll initialize a PromptNode with the `model_name`, `api_key`, and `max_length` to control the output length of the model. In this tutorial, you'll use [OpenAssistant/oasst-sft-1-pythia-12b](https://huggingface.co/OpenAssistant/oasst-sft-1-pythia-12b), an open source Transformer-based text generation model."
+        "You'll initialize a PromptNode with the `model_name`, `api_key`, and `max_length` to control the output length of the model. In this tutorial, you'll use [HuggingFaceH4/zephyr-7b-beta](https://huggingface.co/HuggingFaceH4/zephyr-7b-beta), an open source chat Language Model."
       ]
     },
     {
@@ -156,8 +156,8 @@
       "source": [
         "from haystack.nodes import PromptNode\n",
         "\n",
-        "model_name = \"OpenAssistant/oasst-sft-1-pythia-12b\"\n",
-        "prompt_node = PromptNode(model_name, api_key=model_api_key, max_length=256)"
+        "model_name = \"https://huggingface.co/HuggingFaceH4/zephyr-7b-beta\"\n",
+        "prompt_node = PromptNode(model_name, api_key=model_api_key, max_length=256, stop_words=[\"Human\"])"
       ]
     },
     {


### PR DESCRIPTION
**Why?**
- oasst-sft-1-pythia-12b is outdated: on [Open LLM Leaderboard](https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard), it has an avg of 40 (vs Zephyr 59)

- the model, while supported on the HF Inference API, is quite big and so it is often unavailable/in loading status, as we can see from nightly failures (https://github.com/deepset-ai/haystack-tutorials/actions/runs/7108169282/job/19350972173)

---
I tried the tutorial switching to zephyr-7b-beta and it seems to work well/better.
