### PR TITLE
tutorial 24: fix model_api_key error

### DIFF
--- a/tutorials/24_Building_Chat_App.ipynb
+++ b/tutorials/24_Building_Chat_App.ipynb
@@ -124,7 +124,7 @@
     "import os\n",
     "from getpass import getpass\n",
     "\n",
-    "model_api_key = os.getenv(\"HF_API_KEY\", getpass(\"Enter HF API key:\"))"
+    "model_api_key = os.getenv(\"HF_API_KEY\", None) or getpass(\"Enter HF API key:\")"
    ]
   },
   {


### PR DESCRIPTION
Tries to fix errors like https://github.com/deepset-ai/haystack-tutorials/actions/runs/7161116658/job/19496279465#step:9:32

The expression that I reintroduced worked in the past for reading the `model_api_key`.