### PR TITLE
update import path for in-memory DS and retrievers

### DIFF
--- a/tutorials/27_First_RAG_Pipeline.ipynb
+++ b/tutorials/27_First_RAG_Pipeline.ipynb
@@ -110,7 +110,7 @@
    },
    "outputs": [],
    "source": [
-    "from haystack.document_stores import InMemoryDocumentStore\n",
+    "from haystack.document_stores.in_memory import InMemoryDocumentStore\n",
     "\n",
     "document_store = InMemoryDocumentStore()"
    ]
@@ -243,7 +243,7 @@
    },
    "outputs": [],
    "source": [
-    "from haystack.components.retrievers import InMemoryBM25Retriever\n",
+    "from haystack.components.retrievers.in_memory import InMemoryBM25Retriever\n",
     "\n",
     "retriever = InMemoryBM25Retriever(document_store)"
    ]


### PR DESCRIPTION
https://github.com/deepset-ai/haystack/pull/6714 Introduced a breaking change on the import paths for the in-memory document store and retrievers. This PR should be merged as soon as a new release >beta4 of `haystack-ai` is published