### PR TITLE
Fix datasets installation command

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install Hugging Face datasets
         run: |
-          pip install datasets>=2.6.1
+          pip install "datasets>=2.6.1"
       
       - name: Install ipywidgets for tutorial 24
         run: |

--- a/.github/workflows/run_tutorials.yml
+++ b/.github/workflows/run_tutorials.yml
@@ -36,7 +36,7 @@ jobs:
       
       - name: Install Hugging Face datasets 
         run: |
-          pip install datasets>=2.6.1
+          pip install "datasets>=2.6.1"
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/tutorials/22_Pipeline_with_PromptNode.ipynb
+++ b/tutorials/22_Pipeline_with_PromptNode.ipynb
@@ -79,7 +79,7 @@
     "\n",
     "pip install --upgrade pip\n",
     "pip install farm-haystack[colab]\n",
-    "pip install datasets>=2.6.1"
+    "pip install \"datasets>=2.6.1\""
    ]
   },
   {

--- a/tutorials/25_Customizing_Agent.ipynb
+++ b/tutorials/25_Customizing_Agent.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "pip install --upgrade pip\n",
     "pip install farm-haystack[colab]\n",
-    "pip install datasets>=2.6.1"
+    "pip install \"datasets>=2.6.1\""
    ]
   },
   {

--- a/tutorials/26_Hybrid_Retrieval.ipynb
+++ b/tutorials/26_Hybrid_Retrieval.ipynb
@@ -62,7 +62,7 @@
     "%%bash\n",
     "\n",
     "pip install --upgrade pip\n",
-    "pip install datasets>=2.6.1\n",
+    "pip install \"datasets>=2.6.1\"\n",
     "pip install farm-haystack[inference]"
    ]
   },

--- a/tutorials/27_First_RAG_Pipeline.ipynb
+++ b/tutorials/27_First_RAG_Pipeline.ipynb
@@ -64,7 +64,7 @@
     "%%bash\n",
     "\n",
     "pip install haystack-ai\n",
-    "pip install datasets>=2.6.1"
+    "pip install \"datasets>=2.6.1\""
    ]
   },
   {


### PR DESCRIPTION
Slightly related: https://github.com/deepset-ai/haystack/issues/6353

`pip install datasets>=2.6.1`
installs a version of datasets and creates a "=2.6.1" file...

Should be changed to `pip install "datasets>=2.6.1"`