### PR TITLE
Update `Pipeline` import

### DIFF
--- a/tutorials/27_First_RAG_Pipeline.ipynb
+++ b/tutorials/27_First_RAG_Pipeline.ipynb
@@ -347,7 +347,7 @@
    },
    "outputs": [],
    "source": [
-    "from haystack.pipeline import Pipeline\n",
+    "from haystack import Pipeline\n",
     "\n",
     "basic_rag_pipeline = Pipeline()\n",
     "# Add components to your pipeline\n",

--- a/tutorials/30_File_Type_Preprocessing_Index_Pipeline.ipynb
+++ b/tutorials/30_File_Type_Preprocessing_Index_Pipeline.ipynb
@@ -163,7 +163,7 @@
     "from haystack.components.routers import FileTypeRouter\n",
     "from haystack.components.joiners import DocumentJoiner\n",
     "from haystack.components.embedders import SentenceTransformersDocumentEmbedder\n",
-    "from haystack.pipeline import Pipeline\n",
+    "from haystack import Pipeline\n",
     "from haystack.document_stores.in_memory import InMemoryDocumentStore\n",
     "\n",
     "document_store = InMemoryDocumentStore()\n",


### PR DESCRIPTION
PR deepset-ai/haystack#6973 merges the two definitions of `Pipeline` into a single one in package `haystack.core.pipeline`, `haystack.pipeline` is removed completely.

`from haystack import Pipeline` will continue to work properly instead. This PR changes those tutorials to use that import path.