### PR TITLE
Update import path of `Pipeline` in tutorial 35 LLM Eval

### DIFF
--- a/tutorials/35_Model_Based_Evaluation_of_RAG_Pipelines.ipynb
+++ b/tutorials/35_Model_Based_Evaluation_of_RAG_Pipelines.ipynb
@@ -285,7 +285,7 @@
     }
    ],
    "source": [
-    "from haystack.pipeline import Pipeline\n",
+    "from haystack import Pipeline\n",
     "from haystack.components.builders.answer_builder import AnswerBuilder\n",
     "\n",
     "rag_pipeline = Pipeline()\n",


### PR DESCRIPTION
The new beta release breaks the old import from haystack.pipeline import Pipeline. I changed it to from haystack import Pipeline, which is what we use in all other tutorials too.

Related PRs: https://github.com/deepset-ai/haystack/pull/6973 and https://github.com/deepset-ai/haystack-tutorials/pull/285