### PR TITLE
Hardcode 1.0 version for now

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}  
         run: |
-          VERSION=$(gh api /repos/deepset-ai/haystack/releases/latest | jq -r .tag_name)
+          VERSION=v1.25.0
           NOTEBOOKS=$(python ./scripts/generate_matrix.py --haystack-version "$VERSION" --include-main)
           echo "matrix={\"include\":$NOTEBOOKS}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Since Monday, `gh api /repos/deepset-ai/haystack/releases/latest | jq -r .tag_name` returns v2.0.0, that causes error in tutorial nightly test.
We'll fix this later with 2.0 tutorial tests