### PR TITLE
Change the api key name

### DIFF
--- a/tutorials/24_Building_Chat_App.ipynb
+++ b/tutorials/24_Building_Chat_App.ipynb
@@ -124,7 +124,7 @@
     "import os\n",
     "from getpass import getpass\n",
     "\n",
-    "model_api_key = os.getenv(\"HF_API_TOKEN\", None) or getpass(\"Enter HF API key:\")"
+    "model_api_key = os.getenv(\"HF_API_KEY\", None) or getpass(\"Enter HF API key:\")"
    ]
   },
   {


### PR DESCRIPTION
This is a V1 tutorial so the HF api key name should be `HF_API_KEY`