### PR TITLE
tutorial 5: revisit Mlflow section

### DIFF
--- a/tutorials/05_Evaluation.ipynb
+++ b/tutorials/05_Evaluation.ipynb
@@ -732,7 +732,7 @@
    "metadata": {},
    "source": [
     "## Storing results in MLflow\n",
-    "Storing evaluation results in CSVs is fine but not enough if you want to compare and track multiple evaluation runs. MLflow is a handy tool when it comes to tracking experiments. So we decided to use it to track all of `Pipeline.eval()` with reproducability of your experiments in mind."
+    "Storing evaluation results in CSVs is fine but not enough if you want to compare and track multiple evaluation runs. MLflow is a handy tool when it comes to tracking experiments. So we decided to use it to track all of `Pipeline.eval()` with reproducibility of your experiments in mind."
    ]
   },
   {
@@ -740,15 +740,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Host your own MLflow or use deepset's public MLflow"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you don't want to use deepset's public MLflow instance under https://public-mlflow.deepset.ai, you can easily host it yourself."
+    "### MLflow setup\n",
+    "\n",
+    "Uncomment the following cell to install and run MLflow locally (does not work in Colab). For other options, refer to the [MLflow documentation](https://www.mlflow.org/docs/latest/index.html)."
    ]
   },
   {
@@ -907,8 +901,8 @@
     "    evaluation_set_meta={\"name\": \"nq_dev_subset_v2.json\"},\n",
     "    pipeline_meta={\"name\": \"sparse-pipeline\"},\n",
     "    add_isolated_node_eval=True,\n",
-    "    experiment_tracking_tool=\"mlflow\",\n",
-    "    experiment_tracking_uri=\"https://public-mlflow.deepset.ai\",\n",
+    "    # experiment_tracking_tool=\"mlflow\",                    # UNCOMMENT TO USE MLFLOW\n",
+    "    # experiment_tracking_uri=\"YOUR-MLFLOW-TRACKING-URI\",   # UNCOMMENT TO USE MLFLOW\n",
     "    reuse_index=True,\n",
     ")"
    ]
@@ -948,8 +942,8 @@
     "    evaluation_set_meta={\"name\": \"nq_dev_subset_v2.json\"},\n",
     "    pipeline_meta={\"name\": \"embedding-pipeline\"},\n",
     "    add_isolated_node_eval=True,\n",
-    "    experiment_tracking_tool=\"mlflow\",\n",
-    "    experiment_tracking_uri=\"https://public-mlflow.deepset.ai\",\n",
+    "    # experiment_tracking_tool=\"mlflow\",                    # UNCOMMENT TO USE MLFLOW\n",
+    "    # experiment_tracking_uri=\"YOUR-MLFLOW-TRACKING-URI\",   # UNCOMMENT TO USE MLFLOW\n",
     "    reuse_index=True,\n",
     "    answer_scope=\"context\",\n",
     ")"
@@ -960,9 +954,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can now open MLflow (e.g. https://public-mlflow.deepset.ai/ if you used the public one hosted by deepset) and look for the haystack-eval-experiment experiment. Try out mlflow's compare function and have fun...\n",
-    "\n",
-    "Note that on our public mlflow instance we are not able to log artifacts like the evaluation results or the piplines.yaml file."
+    "You can now open MLflow and look for the haystack-eval-experiment experiment. Try out mlflow's compare function and have fun..."
    ]
   },
   {


### PR DESCRIPTION
public-mlflow.deepset.ai was recently removed
- this causes failures like this: https://github.com/deepset-ai/haystack-tutorials/actions/runs/9965803849/job/27536767949
- the tutorial is misleading

I have tried to fix that, revisiting the Mlflow section, removing mentions to that URL and fixing the code accordingly.