### PR TITLE
Correct an import in Tutorial 39

### DIFF
--- a/tutorials/39_Embedding_Metadata_for_Improved_Retrieval.ipynb
+++ b/tutorials/39_Embedding_Metadata_for_Improved_Retrieval.ipynb
@@ -160,7 +160,7 @@
     "For example, the embedder below will be embedding the \"url\" field as well as the contents of documents:\n",
     "\n",
     "```python\n",
-    "from haystack.components.embedders import SentenceTransformersTextEmbedder\n",
+    "from haystack.components.embedders import SentenceTransformersDocumentEmbedder\n",
     "\n",
     "embedder = SentenceTransformersDocumentEmbedder(meta_fields_to_embed=[\"url\"])\n",
     "```"


### PR DESCRIPTION
Corrects an import for `SentenceTransformersDocumentEmbedder`.