### PR TITLE
chore: Install Haystack stable release instead of main branch

### DIFF
--- a/tutorials/28_Structured_Output_With_Loop.ipynb
+++ b/tutorials/28_Structured_Output_With_Loop.ipynb
@@ -54,7 +54,7 @@
       },
       "source": [
         "## Installing Dependencies\n",
-        "Install Haystack 2.0 and [colorama](https://pypi.org/project/colorama/) with pip:"
+        "Install Haystack and [colorama](https://pypi.org/project/colorama/) with pip:"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "pip install git+https://github.com/deepset-ai/haystack.git@main\n",
+        "pip install haystack-ai\n",
         "pip install colorama"
       ]
     },


### PR DESCRIPTION
We were installing Haystack from main branch but we should use the stable release instead. I tested with 2.3.1 and also already with 2.4.0rc1. Both worked.

The text description mentioned Haystack 2.0. I suggest we don't mention the version.