### PR TITLE
audio tutorial: hide it and do not run tests on it

### DIFF
--- a/.github/workflows/run_tutorials_v1.yml
+++ b/.github/workflows/run_tutorials_v1.yml
@@ -19,7 +19,6 @@ on:
       - "tutorials/14_Query_Classifier.ipynb"
       - "tutorials/15_TableQA.ipynb"
       - "tutorials/16_Document_Classifier_at_Index_Time.ipynb"
-      - "tutorials/17_Audio.ipynb"
       - "tutorials/19_Text_to_Image_search_pipeline_with_MultiModal_Retriever.ipynb"
       - "tutorials/20_Using_Haystack_with_REST_API.ipynb"
       - "tutorials/21_Customizing_PromptNode.ipynb"
@@ -69,7 +68,6 @@ jobs:
             tutorials/14_Query_Classifier.ipynb
             tutorials/15_TableQA.ipynb
             tutorials/16_Document_Classifier_at_Index_Time.ipynb
-            tutorials/17_Audio.ipynb
             tutorials/19_Text_to_Image_search_pipeline_with_MultiModal_Retriever.ipynb
             tutorials/20_Using_Haystack_with_REST_API.ipynb
             tutorials/21_Customizing_PromptNode.ipynb

--- a/index.toml
+++ b/index.toml
@@ -174,6 +174,8 @@ weight = 90
 notebook = "17_Audio.ipynb"
 aliases = ["audio"]
 created_at = 2022-06-07
+hidden = true
+sitemap_exclude = true
 
 [[tutorial]]
 title = "Generative Pseudo Labeling for Domain Adaptation"

--- a/tutorials/17_Audio.ipynb
+++ b/tutorials/17_Audio.ipynb
@@ -9,12 +9,12 @@
    "source": [
     "# Tutorial: Make Your QA Pipelines Talk!\n",
     "\n",
+    ">⚠️**Update:** This tutorial is now outdated and we recommend moving to Haystack >= 2.0 and checking out the new tutorials [here](https://haystack.deepset.ai/tutorials). AnswerToSpeech lives in the [text2speech](https://github.com/deepset-ai/haystack-extras/tree/main/nodes/text2speech) package. Main [Haystack](https://github.com/deepset-ai/haystack) repository doesn't include it anymore.\n",
+    "\n",
     "- **Level**: Intermediate\n",
     "- **Time to complete**: 15 minutes\n",
     "- **Nodes Used**: `InMemoryDocumentStore`, `BM25Retriever`, `FARMReader`, `AnswerToSpeech`\n",
-    "- **Goal**: After completing this tutorial, you'll have created a extractive question answering system that can read out the answer.\n",
-    "\n",
-    ">**Update:** AnswerToSpeech lives in the [text2speech](https://github.com/deepset-ai/haystack-extras/tree/main/nodes/text2speech) package. Main [Haystack](https://github.com/deepset-ai/haystack) repository doesn't include it anymore."
+    "- **Goal**: After completing this tutorial, you'll have created a extractive question answering system that can read out the answer."
    ]
   },
   {


### PR DESCRIPTION
The 1.x audio tutorial is outdated and nightly tests always fail on it.

I've quickly tried to fix it, but the dependency issue is nontrivial and can only be solved by changing the old `text2speech` node.

Therefore, I propose to:
- hide this tutorial
- do not run tests on it