### PR TITLE
Disable testing with v1 main

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
           # Get tutorial notebooks for v1
           VERSION=$(gh api /repos/deepset-ai/haystack/releases | \
             jq -r '[.[].tag_name | select(test("^v1.[0-9]+.[0-9]+$"))] | first')
-          NOTEBOOKS=$(python ./scripts/generate_matrix.py --haystack-version "$VERSION" --include-main)
+          NOTEBOOKS=$(python ./scripts/generate_matrix.py --haystack-version "$VERSION")
           echo "matrix_v1={\"include\":$NOTEBOOKS}" >> "$GITHUB_OUTPUT"
 
           # Get tutorial notebooks for v2

--- a/.github/workflows/run_tutorials_v1.yml
+++ b/.github/workflows/run_tutorials_v1.yml
@@ -47,7 +47,7 @@ jobs:
           # Get tutorial notebooks for 1.x
           VERSION=$(gh api /repos/deepset-ai/haystack/releases | \
             jq -r '[.[].tag_name | select(test("^v1.[0-9]+.[0-9]+$"))] | first')
-          NOTEBOOKS=$(python ./scripts/generate_matrix.py --haystack-version "$VERSION" --include-main)
+          NOTEBOOKS=$(python ./scripts/generate_matrix.py --haystack-version "$VERSION")
           echo "matrix={\"include\":$NOTEBOOKS}" >> "$GITHUB_OUTPUT"
 
       - name: Get changed files


### PR DESCRIPTION
Tests for Haystack 1 are tested both with the latest `v1.26.3` and the unstable `main` version for v1 using the `base-cpu-v1.26.3` and `base-cpu-main` images respectively.

`base-cpu-v1.26.3` has been correctly created 2 months ago when we made that release, though `base-cpu-main` has been created one year ago. 

This is causing nightly to fail for all v1 tutorials when ran using `base-cpu-main`. See [this run](https://github.com/deepset-ai/haystack-tutorials/actions/runs/11430724345) as an example.

Given that v1 will only be getting strictly necessary bug fixes, and it will reach end of life on March 11 2025, and that solving this might mean fixing the release process of Docker images for v1, I think it's best if we just disable testing on the unstable.

If there needs be for a new release of v1 we can test manually before releasing it, and fix accordingly. 

Also we should push newcomers and people that are starting now to use the latest Haystack version and not v1.