### PR TITLE
chore: Pin numpy<2 on nightly runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,6 +63,7 @@ jobs:
         # remove pip install pyzmq when this is resolved https://github.com/zeromq/pyzmq/issues/1764
         run: |
           apt-get update && apt-get install -y build-essential gcc libsndfile1 ffmpeg && rm -rf /var/lib/apt/lists/*
+          pip install "numpy<2"
           pip install pyzmq==23.2.1
           pip install nbconvert ipython
           pip install "pyworld<=0.2.12" espnet espnet-model-zoo pydub


### PR DESCRIPTION
Nightlies for 1.x started to fail after 1.24.6 was released. In nightlies run, somehow numpy 2.x got installed while previously 1.x was installed. Numpy 2.x caused failing of pyworld wheel building. The solution we are trying here involves pinning Numpy to a version below 2.0 (e.g., `numpy<2.0`) to ensure compatibility.