### PR TITLE
Simplify tutorial 29

### DIFF
--- a/tutorials/29_Serializing_Pipelines.ipynb
+++ b/tutorials/29_Serializing_Pipelines.ipynb
@@ -386,8 +386,6 @@
    "outputs": [],
    "source": [
     "from haystack import Pipeline\n",
-    "from haystack.components.builders import ChatPromptBuilder\n",
-    "from haystack.components.generators.chat import HuggingFaceLocalChatGenerator\n",
     "\n",
     "new_pipeline = Pipeline.loads(yaml_pipeline)"
    ]

--- a/tutorials/29_Serializing_Pipelines.ipynb
+++ b/tutorials/29_Serializing_Pipelines.ipynb
@@ -146,7 +146,7 @@
     "]\n",
     "\n",
     "builder = ChatPromptBuilder(template=template)\n",
-    "llm = HuggingFaceLocalChatGenerator(model=\"Qwen/Qwen2.5-0.5B-Instruct\", generation_kwargs={\"max_new_tokens\": 150})\n",
+    "llm = HuggingFaceLocalChatGenerator(model=\"Qwen/Qwen2.5-1.5B-Instruct\", generation_kwargs={\"max_new_tokens\": 150})\n",
     "\n",
     "pipeline = Pipeline()\n",
     "pipeline.add_component(name=\"builder\", instance=builder)\n",
@@ -170,7 +170,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Climate change is a global issue that has been on the rise in recent years due to various factors such as human activities, natural disasters, and climate variability. The impacts of climate change can be seen in extreme weather events, rising sea levels, melting ice caps, and changing ecosystems.\nThere are different types of climate change, including global warming, local climate change, and regional climate change. Global warming refers to changes in the Earth's temperature caused by greenhouse gas emissions from human activities, while local climate change refers to changes in the climate of specific areas or regions.\nTo address climate change, there needs to be a concerted effort from governments, businesses, and individuals around the world to reduce greenhouse gas emissions, protect natural habitats, and invest in renewable energy sources\n"
+      "Climate change is a global issue that has been on the rise in recent years due to various factors such as human activities, natural disasters, and climate variability. The impacts of climate change can be seen in extreme weather events, rising sea levels, melting ice caps, and changing ecosystems.\n",
+      "There are different types of climate change, including global warming, local climate change, and regional climate change. Global warming refers to changes in the Earth's temperature caused by greenhouse gas emissions from human activities, while local climate change refers to changes in the climate of specific areas or regions.\n",
+      "To address climate change, there needs to be a concerted effort from governments, businesses, and individuals around the world to reduce greenhouse gas emissions, protect natural habitats, and invest in renewable energy sources\n"
      ]
     }
    ],
@@ -229,9 +231,9 @@
       "        max_new_tokens: 150\n",
       "        stop_sequences: []\n",
       "      huggingface_pipeline_kwargs:\n",
-      "        device: mps\n",
-      "        model: google/flan-t5-large\n",
-      "        task: text2text-generation\n",
+      "        device: cpu\n",
+      "        model: Qwen/Qwen2.5-1.5B-Instruct\n",
+      "        task: text-generation\n",
       "      streaming_callback: null\n",
       "      token:\n",
       "        env_vars:\n",
@@ -289,8 +291,8 @@
     "        stop_sequences: []\n",
     "      huggingface_pipeline_kwargs:\n",
     "        device: cpu\n",
-    "        model: google/flan-t5-large\n",
-    "        task: text2text-generation\n",
+    "        model: Qwen/Qwen2.5-1.5B-Instruct\n",
+    "        task: text-generation\n",
     "      streaming_callback: null\n",
     "      token:\n",
     "        env_vars:\n",
@@ -345,8 +347,8 @@
     "        stop_sequences: []\n",
     "      huggingface_pipeline_kwargs:\n",
     "        device: cpu\n",
-    "        model: google/flan-t5-large\n",
-    "        task: text2text-generation\n",
+    "        model: Qwen/Qwen2.5-1.5B-Instruct\n",
+    "        task: text-generation\n",
     "      streaming_callback: null\n",
     "      chat_template : \"{% for message in messages %}{% if message['role'] == 'user' %}{{ ' ' }}{% endif %}{{ message['content'] }}{% if not loop.last %}{{ '  ' }}{% endif %}{% endfor %}{{ eos_token }}\"\n",
     "      token:\n",
@@ -413,7 +415,7 @@
     {
      "data": {
       "text/plain": [
-       "{'llm': {'replies': [ChatMessage(content='Je me félicite des capybaras', role=<ChatRole.ASSISTANT: 'assistant'>, name=None, meta={'finish_reason': 'stop', 'index': 0, 'model': 'google/flan-t5-large', 'usage': {'completion_tokens': 13, 'prompt_tokens': 16, 'total_tokens': 29}})]}}"
+       "{'llm': {'replies': [ChatMessage(content='J'aime les capybaras', role=<ChatRole.ASSISTANT: 'assistant'>, name=None, meta={'finish_reason': 'stop', 'index': 0, 'model': 'Qwen/Qwen2.5-1.5B-Instruct', 'usage': {'completion_tokens': 13, 'prompt_tokens': 16, 'total_tokens': 29}})]}}"
       ]
      },
      "execution_count": 7,

--- a/tutorials/29_Serializing_Pipelines.ipynb
+++ b/tutorials/29_Serializing_Pipelines.ipynb
@@ -85,22 +85,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "id": "ikIM1o9cHNcS"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/amna.mubashar/Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020\n",
-      "  warnings.warn(\n",
-      "/Users/amna.mubashar/Library/Python/3.9/lib/python/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from haystack.telemetry import tutorial_running\n",
     "\n",
@@ -147,17 +136,17 @@
     "from haystack.dataclasses import ChatMessage\n",
     "from haystack.components.generators.chat import HuggingFaceLocalChatGenerator\n",
     "\n",
-    "template = [ChatMessage.from_user(\"\"\"\n",
+    "template = [\n",
+    "    ChatMessage.from_user(\n",
+    "        \"\"\"\n",
     "Please create a summary about the following topic:\n",
     "{{ topic }}\n",
-    "\"\"\")]\n",
-    "chat_template = \"{% for message in messages %}{% if message['role'] == 'user' %}{{ ' ' }}{% endif %}{{ message['content'] }}{% if not loop.last %}{{ '  ' }}{% endif %}{% endfor %}{{ eos_token }}\"\n",
+    "\"\"\"\n",
+    "    )\n",
+    "]\n",
     "\n",
     "builder = ChatPromptBuilder(template=template)\n",
-    "llm = HuggingFaceLocalChatGenerator(\n",
-    "    model=\"google/flan-t5-large\", task=\"text2text-generation\", generation_kwargs={\"max_new_tokens\": 150},\n",
-    "    chat_template=chat_template\n",
-    ")\n",
+    "llm = HuggingFaceLocalChatGenerator(model=\"Qwen/Qwen2.5-0.5B-Instruct\", generation_kwargs={\"max_new_tokens\": 150})\n",
     "\n",
     "pipeline = Pipeline()\n",
     "pipeline.add_component(name=\"builder\", instance=builder)\n",
@@ -181,7 +170,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Climate change is a major threat to the planet.\n"
+      "Climate change is a global issue that has been on the rise in recent years due to various factors such as human activities, natural disasters, and climate variability. The impacts of climate change can be seen in extreme weather events, rising sea levels, melting ice caps, and changing ecosystems.\nThere are different types of climate change, including global warming, local climate change, and regional climate change. Global warming refers to changes in the Earth's temperature caused by greenhouse gas emissions from human activities, while local climate change refers to changes in the climate of specific areas or regions.\nTo address climate change, there needs to be a concerted effort from governments, businesses, and individuals around the world to reduce greenhouse gas emissions, protect natural habitats, and invest in renewable energy sources\n"
      ]
     }
    ],


### PR DESCRIPTION
I looked at this tutorial due to recent tests failures.

This PR does not fix the deserialization issue (which cannot be fixed before 2.9.0 and only affects installation from main branch).
I'll open another PR for that.

I'm simply getting rid of `chat_template`, which is not needed if we choose more modern LLMs (automatically coming with their template).
I'm using Qwen/Qwen2.5-1.5B-Instruct, a small LM which is good and can run quickly on CPU too.

**This is expected to pass with 2.8.0 and fail with main**