### PR TITLE
chore: comment Pipeline.draw commands

### DIFF
--- a/tutorials/28_Structured_Output_With_Loop.ipynb
+++ b/tutorials/28_Structured_Output_With_Loop.ipynb
@@ -403,7 +403,7 @@
    },
    "outputs": [],
    "source": [
-    "pipeline.draw(\"auto-correct-pipeline.png\")"
+    "# pipeline.draw(\"auto-correct-pipeline.png\")"
    ]
   },
   {

--- a/tutorials/32_Classifying_Documents_and_Queries_by_Language.ipynb
+++ b/tutorials/32_Classifying_Documents_and_Queries_by_Language.ipynb
@@ -288,7 +288,7 @@
    },
    "outputs": [],
    "source": [
-    "indexing_pipeline.draw(\"indexing_pipeline.png\")"
+    "# indexing_pipeline.draw(\"indexing_pipeline.png\")"
    ]
   },
   {
@@ -537,7 +537,7 @@
    },
    "outputs": [],
    "source": [
-    "rag_pipeline.draw(\"rag_pipeline.png\")"
+    "# rag_pipeline.draw(\"rag_pipeline.png\")"
    ]
   },
   {

--- a/tutorials/33_Hybrid_Retrieval.ipynb
+++ b/tutorials/33_Hybrid_Retrieval.ipynb
@@ -362,7 +362,7 @@
    },
    "outputs": [],
    "source": [
-    "hybrid_retrieval.draw(\"hybrid-retrieval.png\")"
+    "# hybrid_retrieval.draw(\"hybrid-retrieval.png\")"
    ]
   },
   {

--- a/tutorials/36_Building_Fallbacks_with_Conditional_Routing.ipynb
+++ b/tutorials/36_Building_Fallbacks_with_Conditional_Routing.ipynb
@@ -405,7 +405,7 @@
    },
    "outputs": [],
    "source": [
-    "pipe.draw(\"pipe.png\")"
+    "# pipe.draw(\"pipe.png\")"
    ]
   },
   {


### PR DESCRIPTION
Our tutorials nightly tests often fail due to Mermaid timeouts.  Related to https://github.com/deepset-ai/haystack/issues/9107
This way, we don't notice more important failures.

In this PR, I'm commenting `Pipeline.draw` commands in tutorials to stop them from being executed in nightly tests.