### PR TITLE
Update 45_Creating_a_Multi_Agent_System.ipynb

### DIFF
--- a/tutorials/45_Creating_a_Multi_Agent_System.ipynb
+++ b/tutorials/45_Creating_a_Multi_Agent_System.ipynb
@@ -634,6 +634,7 @@
     "    tools=[doc_store_writer, notion_writer],\n",
     "    streaming_callback=print_streaming_chunk,\n",
     "    exit_conditions=[\"notion_writer\", \"doc_store_writer\"],\n",
+    "    outputs_to_string={\"source\":, \"last_message\"},\n",
     ")"
    ]
   },


### PR DESCRIPTION
Add `outputs_to_string` in `writer_agent` when defining `ComponentTool` so we only send the last message from the Agent as a Tool. Otherwise the whole output of the Agent is returned including all messages it generated internally. 