### PR TITLE
tutorial 30: better model and configuration

### DIFF
--- a/tutorials/30_File_Type_Preprocessing_Index_Pipeline.ipynb
+++ b/tutorials/30_File_Type_Preprocessing_Index_Pipeline.ipynb
@@ -339,7 +339,7 @@
     "id": "I06qdWsZibSz"
    },
    "source": [
-    "Now, let's build a RAG pipeline that answers queries based on the documents you just created in the section above. For this step, we will be using the [`HuggingFaceAPIChatGenerator`](https://docs.haystack.deepset.ai/docs/huggingfaceapichatgenerator) so must have a [Hugging Face API Key](https://huggingface.co/settings/tokens) for this section. We will be using the `HuggingFaceH4/zephyr-7b-beta` model."
+    "Now, let's build a RAG pipeline that answers queries based on the documents you just created in the section above. For this step, we will be using the [`HuggingFaceAPIChatGenerator`](https://docs.haystack.deepset.ai/docs/huggingfaceapichatgenerator) so must have a [Hugging Face API Key](https://huggingface.co/settings/tokens) for this section. We will be using the `Qwen/Qwen2.5-7B-Instruct` model."
    ]
   },
   {
@@ -376,7 +376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -435,7 +435,8 @@
     "pipe.add_component(\n",
     "    \"llm\",\n",
     "    HuggingFaceAPIChatGenerator(\n",
-    "        api_type=\"serverless_inference_api\", api_params={\"model\": \"HuggingFaceH4/zephyr-7b-beta\"}\n",
+    "        api_type=\"serverless_inference_api\",\n",
+    "        api_params={\"model\": \"Qwen/Qwen2.5-7B-Instruct\", \"provider\": \"together\"}\n",
     "    ),\n",
     ")\n",
     "\n",
@@ -455,29 +456,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "id": "qDqrU5emtBWQ"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Batches: 100%|██████████| 1/1 [00:00<00:00,  3.20it/s]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'llm': {'replies': [ChatMessage(content=\"For vegan keto eggplant lasagna:\\n- 2 large eggplants\\n- Hella salt (optional)\\n- 1/2 cup store-bought vegan mozzarella cheese (for topping)\\n- Pesto:\\n  - 4 oz basil (generally one large clamshell or 2 small ones)\\n  - 1/4 cup almonds\\n  - 1/4 cup nutritional yeast\\n  - 1/4 cup olive oil\\n- Spinach tofu ricotta:\\n  - 1 recipe spinach tofu ricotta\\n- 1 tsp garlic powder\\n- Juice of half a lemon\\n- Salt to taste\\n\\nFor macadamia nut cheese:\\n- 1 cup macadamia nuts (unsalted and unroasted)\\n- Salt (optional)\\n\\nInstructions:\\n1. Preheat oven to 400°F.\\n2. Slice eggplants into 1/4 inch thick slices and rub both sides with salt. Let sit for 20-30 minutes to extract moisture. Rinse with water and pat dry.\\n3. Roast the eggplant in the oven for about 20 minutes or until they're soft and brown in spots, rotating the pans halfway through.\\n4. Reduce oven temperature to 350°F.\\n5. In a separate bowl, mix together the store-bought vegan mozzarella cheese (for topping) with spinach tofu ricotta.\\n6. Assemble the lasagna: spread a layer of roasted eggplant at the bottom of the casserole dish, followed by a layer of pesto and a layer of the cheese mixture. Repeat until all ingredients are used, finishing with a layer of roasted eggplant. Sprinkle the remaining store-bought vegan mozzarella cheese (for topping) on top.\\n7. Bake for 25 minutes. Optionally, broil for 1-2 minutes at the end to melt the cheese.\\n\\nFor vegan persimmon flan:\\n- 1/2 cup persimmon pulp, strained (about 2 medium persimmons)\\n- 1 tbsp cornstarch\\n- 1/2 tsp agar agar\\n-\", role=<ChatRole.ASSISTANT: 'assistant'>, name=None, meta={'model': 'HuggingFaceH4/zephyr-7b-beta', 'finish_reason': 'length', 'index': 0, 'usage': ChatCompletionOutputUsage(completion_tokens=512, prompt_tokens=2276, total_tokens=2788)})]}}"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "question = (\n",
     "    \"What ingredients would I need to make vegan keto eggplant lasagna, vegan persimmon flan, and vegan hemp cheese?\"\n",
@@ -492,7 +475,7 @@
     "id": "ZJueu_V4KP6w"
    },
    "source": [
-    "{'llm': {'replies': [ChatMessage(content=\"For vegan keto eggplant lasagna:\\n- 2 large eggplants\\n- Hella salt (optional)\\n- 1/2 cup store-bought vegan mozzarella cheese (for topping)\\n- Pesto:\\n  - 4 oz basil (generally one large clamshell or 2 small ones)\\n  - 1/4 cup almonds\\n  - 1/4 cup nutritional yeast\\n  - 1/4 cup olive oil\\n- Spinach tofu ricotta:\\n  - 1 recipe spinach tofu ricotta\\n- 1 tsp garlic powder\\n- Juice of half a lemon\\n- Salt to taste\\n\\nFor macadamia nut cheese:\\n- 1 cup macadamia nuts (unsalted and unroasted)\\n- Salt (optional)\\n\\nInstructions:\\n1. Preheat oven to 400°F.\\n2. Slice eggplants into 1/4 inch thick slices and rub both sides with salt. Let sit for 20-30 minutes to extract moisture. Rinse with water and pat dry.\\n3. Roast the eggplant in the oven for about 20 minutes or until they're soft and brown in spots, rotating the pans halfway through.\\n4. Reduce oven temperature to 350°F.\\n5. In a separate bowl, mix together the store-bought vegan mozzarella cheese (for topping) with spinach tofu ricotta.\\n6. Assemble the lasagna: spread a layer of roasted eggplant at the bottom of the casserole dish, followed by a layer of pesto and a layer of the cheese mixture. Repeat until all ingredients are used, finishing with a layer of roasted eggplant. Sprinkle the remaining store-bought vegan mozzarella cheese (for topping) on top.\\n7. Bake for 25 minutes. Optionally, broil for 1-2 minutes at the end to melt the cheese.\\n\\nFor vegan persimmon flan:\\n- 1/2 cup persimmon pulp, strained (about 2 medium persimmons)\\n- 1 tbsp cornstarch\\n- 1/2 tsp agar agar\\n-\", role=<ChatRole.ASSISTANT: 'assistant'>, name=None, meta={'model': 'HuggingFaceH4/zephyr-7b-beta', 'finish_reason': 'length', 'index': 0, 'usage': ChatCompletionOutputUsage(completion_tokens=512, prompt_tokens=2276, total_tokens=2788)})]}}"
+    "{'llm': {'replies': [ChatMessage(_role=<ChatRole.ASSISTANT: 'assistant'>, _content=[TextContent(text='To make vegan keto eggplant lasagna, vegan persimmon flan, and vegan hemp cheese, you would need the following ingredients:\\n\\n### Vegan Keto Eggplant Lasagna\\n- 2 large eggplants\\n- Salt (Hella salt)\\n- 1/2 cup store-bought vegan mozzarella for topping\\n- Pesto (ingredients: 4 oz basil, 1/4 cup almonds, 1/4 cup nutritional yeast, 1/4 cup olive oil, 1 recipe vegan pesto)\\n- Spinach Tofu Ricotta (14 oz firm or extra firm tofu, 10 oz spinach, juice of 1 lemon, garlic powder to taste, salt to taste)\\n- Macadamia Nut Cheese (1 cup macadamia nuts, 1/4 cup nutritional yeast, 1/4 cup olive oil, 1 recipe vegan pesto, 1 recipe spinach tofu ricotta, 1 tsp garlic powder, juice of half a lemon, salt to taste)\\n\\n### Vegan Persimmon Flan\\n- 2 average-sized fuyu persimmons, strained\\n- 1 tbsp cornstarch\\n- 1/2 tsp agar agar\\n- 1 tbsp agave nectar, or to taste\\n- 2 tbsp granulated sugar\\n- 1/4 cup coconut creme\\n- 1/2 cup almond milk\\n- 1/2 tsp vanilla\\n\\n### Vegan Hemp Cheese\\n- 1/2 cup sunflower seeds\\n- 1/2 cup hemp hearts\\n- 1.5 teaspoons miso paste\\n- 1 tsp nutritional yeast\\n- 1/4 cup rejuvelac\\n- 1/4th teaspoon salt, or to taste\\n\\n### Additional Tools and Notes\\n- Casserole dish (9 x 13)\\n- 2 ramekins\\n- Blender or food processor\\n- Saucepan\\n- Immersion blender (optional)\\n- Clean glass bowl\\n- Rubber band\\n- Dish towel\\n- Knife\\n- Hot water bath method (for flan)\\n\\nThese ingredients and tools will allow you to prepare all three dishes as described in the provided context.')], _name=None, _meta={'model': 'Qwen/Qwen2.5-7B-Instruct', 'finish_reason': 'stop', 'index': 0, 'usage': {'prompt_tokens': 2031, 'completion_tokens': 446}})]}}"
    ]
   },
   {


### PR DESCRIPTION
Tests for tutorial 30 are failing. https://github.com/deepset-ai/haystack-tutorials/actions/runs/16431007196/job/46432251109#step:7:30
This also depends on the fact that the model used is no longer available on the HF API.

In this PR, I'm replacing the Zephyr model with a better one, available on the HF API.
I'm also specifying a `provider` (necessary for the reasons exposed in https://github.com/deepset-ai/haystack/issues/9586).