### PR TITLE
tut 46: fix images download

### DIFF
--- a/tutorials/46_Multimodal_RAG.ipynb
+++ b/tutorials/46_Multimodal_RAG.ipynb
@@ -130,26 +130,26 @@
     "outputId": "08febdb6-3e36-4330-bed8-385710eb3339",
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('capybara.jpg', <http.client.HTTPMessage at 0x7b1a2bfad8d0>)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from urllib.request import URLopener\n",
+    "import shutil\n",
+    "from urllib.request import Request, urlopen\n",
     "\n",
-    "url_opener = URLopener()\n",
-    "url_opener.addheader(\"User-Agent\", \"Mozilla/5.0\")\n",
+    "HEADERS = {\"User-Agent\": \"haystack-tutorials\"}\n",
     "\n",
-    "url_opener.retrieve(\"https://upload.wikimedia.org/wikipedia/commons/2/26/Pink_Lady_Apple_%284107712628%29.jpg?download\", \"apple.jpg\")\n",
-    "url_opener.retrieve(\"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Cattle_tyrant_%28Machetornis_rixosa%29_on_Capybara.jpg/960px-Cattle_tyrant_%28Machetornis_rixosa%29_on_Capybara.jpg?download\", \"capybara.jpg\")"
+    "def download_image(url, filename):\n",
+    "    req = Request(url, headers=HEADERS)\n",
+    "    with urlopen(req) as r, open(filename, \"wb\") as f:\n",
+    "        shutil.copyfileobj(r, f)\n",
+    "\n",
+    "download_image(\n",
+    "    \"https://upload.wikimedia.org/wikipedia/commons/2/26/Pink_Lady_Apple_%284107712628%29.jpg\",\n",
+    "    \"apple.jpg\",\n",
+    ")\n",
+    "download_image(\n",
+    "    \"https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Cattle_tyrant_%28Machetornis_rixosa%29_on_Capybara.jpg/960px-Cattle_tyrant_%28Machetornis_rixosa%29_on_Capybara.jpg\",\n",
+    "    \"capybara.jpg\",\n",
+    ")"
    ]
   },
   {
@@ -350,12 +350,7 @@
     }
    ],
    "source": [
-    "from urllib.request import URLopener\n",
-    "\n",
-    "url_opener = URLopener()\n",
-    "url_opener.addheader(\"User-Agent\", \"Mozilla/5.0\")\n",
-    "\n",
-    "url_opener.retrieve(\"https://arxiv.org/pdf/1706.03762\", \"attention_is_all_you_need.pdf\")"
+    "download_image(\"https://arxiv.org/pdf/1706.03762\", \"attention_is_all_you_need.pdf\")"
    ]
   },
   {


### PR DESCRIPTION
Image download in tutorial 46 is broken: https://github.com/deepset-ai/haystack-tutorials/actions/runs/26198224037/job/77082339645

This mostly happens because Wikimedia started blocking the generic user-agent.

I'm fixing this and also avoiding some deprecated Python functions.