### PR TITLE
tut 39 - try setting user agent to prevent wikipedia error

### DIFF
--- a/tutorials/39_Embedding_Metadata_for_Improved_Retrieval.ipynb
+++ b/tutorials/39_Embedding_Metadata_for_Improved_Retrieval.ipynb
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -169,6 +169,8 @@
     "import wikipedia\n",
     "from haystack import Document\n",
     "from haystack.document_stores.in_memory import InMemoryDocumentStore\n",
+    "\n",
+    "wikipedia.set_user_agent(\"haystack-tutorials\")\n",
     "\n",
     "some_bands = \"\"\"The Beatles,The Cure\"\"\".split(\",\")\n",
     "\n",


### PR DESCRIPTION
Lately this tutorial has been failing: https://github.com/deepset-ai/haystack-tutorials/actions/runs/26377207565/job/77639521030

This likely happens due to new user agent policies in Wikipedia.
I'm now trying to set an explicit user agent to avoid these errors.