### PR TITLE
Fix typo in Metadata Filtering Tutorial

### DIFF
--- a/tutorials/31_Metadata_Filtering.ipynb
+++ b/tutorials/31_Metadata_Filtering.ipynb
@@ -140,7 +140,7 @@
     "\n",
     "Finally, ask a question by filtering the documents to `\"version\" > 1.21`.\n",
     "\n",
-    "To see what kind of comparison operators you can use for your metadata, including logical comparistons such as `NOT`, `AND` and so on, check out the [Metadata Filtering documentation](https://docs.haystack.deepset.ai/docs/metadata-filtering#comparison)"
+    "To see what kind of comparison operators you can use for your metadata, including logical comparisons such as `NOT`, `AND` and so on, check out the [Metadata Filtering documentation](https://docs.haystack.deepset.ai/docs/metadata-filtering#comparison)"
    ]
   },
   {


### PR DESCRIPTION
## Description
Fixes a small typographical error in the "Filtering Documents with Metadata" tutorial notebook text. 

Changed `comparistons` to `comparisons` in the markdown description under the **Do Metadata Filtering** section to keep the documentation clear and polished.

## Type of Change
- [x] Bug report / Documentation fix (non-breaking change fixing an error or typo)

## Checklist
- [x] I have made the necessary changes directly within the corresponding `.ipynb` file.
- [x] Pre-commit hooks ran successfully during the commit phase.