### PR TITLE
tut 30 - update for HF API components

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -48,8 +48,7 @@ completion_time = "15 min"
 created_at = 2024-01-30
 dependencies = [
     "sentence-transformers>=4.1.0",
-    "huggingface_hub>=0.23.0",
-    "transformers",
+    "huggingface-api-haystack",
     "markdown-it-py",
     "mdit_plain",
     "pypdf",

--- a/tutorials/30_File_Type_Preprocessing_Index_Pipeline.ipynb
+++ b/tutorials/30_File_Type_Preprocessing_Index_Pipeline.ipynb
@@ -390,7 +390,7 @@
     "from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever\n",
     "from haystack.components.builders import ChatPromptBuilder\n",
     "from haystack.dataclasses import ChatMessage\n",
-    "from haystack.components.generators.chat import HuggingFaceAPIChatGenerator\n",
+    "from haystack_integrations.components.generators.huggingface_api import HuggingFaceAPIChatGenerator\n",
     "\n",
     "template = [\n",
     "    ChatMessage.from_user(\n",

--- a/tutorials/30_File_Type_Preprocessing_Index_Pipeline.ipynb
+++ b/tutorials/30_File_Type_Preprocessing_Index_Pipeline.ipynb
@@ -57,8 +57,8 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "pip install haystack-ai\n",
-    "pip install \"sentence-transformers>=4.1.0\" \"huggingface_hub>=0.23.0\"\n",
+    "pip install haystack-ai huggingface-api-haystack\n",
+    "pip install \"sentence-transformers>=4.1.0\"\n",
     "pip install markdown-it-py mdit_plain pypdf\n",
     "pip install gdown"
    ]


### PR DESCRIPTION
part of https://github.com/deepset-ai/haystack-private/issues/365

This component now also lives in core integrations.
Starting from Haystack 3.0, it will be removed from Haystack, so better to start updating tutorials.