### PR TITLE
Update tutorials 36, 43, 45 for new serperdev-haystack package

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -120,7 +120,7 @@ notebook = "36_Building_Fallbacks_with_Conditional_Routing.ipynb"
 aliases = []
 completion_time = "10 min"
 created_at = 2024-02-16
-dependencies = []
+dependencies = ["serperdev-haystack"]
 featured = true
 
 [[tutorial]]
@@ -187,7 +187,7 @@ notebook = "43_Building_a_Tool_Calling_Agent.ipynb"
 aliases = []
 completion_time = "10 min"
 created_at = 2025-04-03
-dependencies = ["docstring-parser", "trafilatura"]
+dependencies = ["docstring-parser", "trafilatura", "serperdev-haystack"]
 featured = true
 
 [[tutorial]]

--- a/tutorials/36_Building_Fallbacks_with_Conditional_Routing.ipynb
+++ b/tutorials/36_Building_Fallbacks_with_Conditional_Routing.ipynb
@@ -70,7 +70,7 @@
    "source": [
     "%%bash\n",
     "\n",
-    "pip install haystack-ai"
+    "pip install haystack-ai serperdev-haystack"
    ]
   },
   {
@@ -241,7 +241,7 @@
    },
    "outputs": [],
    "source": [
-    "from haystack.components.websearch.serper_dev import SerperDevWebSearch\n",
+    "from haystack_integrations.components.websearch.serperdev import SerperDevWebSearch\n",
     "\n",
     "prompt_for_websearch = [\n",
     "    ChatMessage.from_user(\n",

--- a/tutorials/43_Building_a_Tool_Calling_Agent.ipynb
+++ b/tutorials/43_Building_a_Tool_Calling_Agent.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "%%bash\n",
     "\n",
-    "pip install haystack-ai docstring-parser trafilatura"
+    "pip install haystack-ai serperdev-haystack docstring-parser trafilatura"
    ]
   },
   {
@@ -96,7 +96,7 @@
    "source": [
     "from haystack.components.agents import Agent\n",
     "from haystack.components.generators.chat import OpenAIChatGenerator\n",
-    "from haystack.components.websearch import SerperDevWebSearch\n",
+    "from haystack_integrations.components.websearch.serperdev import SerperDevWebSearch\n",
     "from haystack.dataclasses import ChatMessage\n",
     "from haystack.tools.component_tool import ComponentTool\n",
     "\n",
@@ -198,7 +198,7 @@
     "from haystack.components.converters.html import HTMLToDocument\n",
     "from haystack.components.converters.output_adapter import OutputAdapter\n",
     "from haystack.components.fetchers.link_content import LinkContentFetcher\n",
-    "from haystack.components.websearch.serper_dev import SerperDevWebSearch\n",
+    "from haystack_integrations.components.websearch.serperdev import SerperDevWebSearch\n",
     "from haystack.dataclasses import ChatMessage\n",
     "from haystack.core.pipeline import Pipeline\n",
     "\n",
@@ -242,7 +242,8 @@
     "id": "yxaN3KBo65pv"
    },
    "outputs": [],
-   "source": "from haystack.tools import PipelineTool\nfrom haystack.components.agents import Agent\nfrom haystack.components.generators.chat import OpenAIChatGenerator\n\nsearch_tool = PipelineTool(\n    name=\"search\",\n    description=\"Use this tool to search for information on the internet.\",\n    pipeline=search_pipeline,\n    input_mapping={\"query\": [\"search.query\"]},\n    output_mapping={\"output_adapter.output\": \"search_result\"},\n    outputs_to_string={\"source\": \"search_result\"},\n)\n\nagent = Agent(\n    chat_generator=OpenAIChatGenerator(model=\"gpt-4o-mini\"),\n    tools=[search_tool],\n    system_prompt=\"\"\"\n    You are a deep research assistant.\n    You create comprehensive research reports to answer the user's questions.\n    You use the 'search'-tool to answer any questions.\n    You perform multiple searches until you have the information you need to answer the question.\n    Make sure you research different aspects of the question.\n    Use markdown to format your response.\n    When you use information from the websearch results, cite your sources using markdown links.\n    It is important that you cite accurately.\n    \"\"\",\n    exit_conditions=[\"text\"],\n    max_agent_steps=20,\n)"  },
+   "source": "from haystack.tools import PipelineTool\nfrom haystack.components.agents import Agent\nfrom haystack.components.generators.chat import OpenAIChatGenerator\n\nsearch_tool = PipelineTool(\n    name=\"search\",\n    description=\"Use this tool to search for information on the internet.\",\n    pipeline=search_pipeline,\n    input_mapping={\"query\": [\"search.query\"]},\n    output_mapping={\"output_adapter.output\": \"search_result\"},\n    outputs_to_string={\"source\": \"search_result\"},\n)\n\nagent = Agent(\n    chat_generator=OpenAIChatGenerator(model=\"gpt-4o-mini\"),\n    tools=[search_tool],\n    system_prompt=\"\"\"\n    You are a deep research assistant.\n    You create comprehensive research reports to answer the user's questions.\n    You use the 'search'-tool to answer any questions.\n    You perform multiple searches until you have the information you need to answer the question.\n    Make sure you research different aspects of the question.\n    Use markdown to format your response.\n    When you use information from the websearch results, cite your sources using markdown links.\n    It is important that you cite accurately.\n    \"\"\",\n    exit_conditions=[\"text\"],\n    max_agent_steps=20,\n)"
+  },
   {
    "cell_type": "markdown",
    "metadata": {

--- a/tutorials/45_Creating_a_Multi_Agent_System.ipynb
+++ b/tutorials/45_Creating_a_Multi_Agent_System.ipynb
@@ -163,7 +163,7 @@
     "id": "C5qn6kyJ2hSX"
    },
    "source": [
-    "If you're hitting rate limits with DuckDuckGo, you can use [`SerperDevWebSearch`](https://docs.haystack.deepset.ai/docs/serperdevwebsearch) as your websearch component for these tools. You need to enter the free [Serper API Key](https://serper.dev/api-key) to use `SerperDevWebSearch`. "
+    "If you're hitting rate limits with DuckDuckGo, you can use [`SerperDevWebSearch`](https://docs.haystack.deepset.ai/docs/serperdevwebsearch) as your websearch component for these tools. You need to install the `serperdev-haystack` package with `pip install serperdev-haystack` and enter the free [Serper API Key](https://serper.dev/api-key) to use `SerperDevWebSearch`. "
    ]
   },
   {
@@ -177,7 +177,7 @@
     "# from getpass import getpass\n",
     "# import os\n",
     "\n",
-    "# from haystack.components.websearch import SerperDevWebSearch\n",
+    "# from haystack_integrations.components.websearch.serperdev import SerperDevWebSearch\n",
     "# from haystack.tools import ComponentTool\n",
     "\n",
     "# if not os.environ.get(\"SERPERDEV_API_KEY\"):\n",


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/369

### Proposed Changes:
- update tutorials 36, 43, and 45 for the new `serperdev-haystack` package: `SerperDevWebSearch` moved from Haystack core to [haystack-core-integrations](https://github.com/deepset-ai/haystack-core-integrations/pull/3425)
- install commands now include `serperdev-haystack`; imports changed to `from haystack_integrations.components.websearch.serperdev import SerperDevWebSearch`
- `index.toml`: added `serperdev-haystack` to the dependencies of tutorials 36 and 43 so CI installs it

### How did you test it?
- ran tutorials 36 and 43 end-to-end locally (nbconvert to Python, like CI) with real `OPENAI_API_KEY` and `SERPERDEV_API_KEY` and the new package installed from the integration branch: both completed successfully
- tutorial 45: only a markdown note and a commented-out optional snippet changed; verified the uncommented snippet (ComponentTool + SerperDevWebSearch from the new package) works against the live Serper API (a full run additionally requires a `NOTION_API_KEY`)

### Notes for the reviewer
- `serperdev-haystack` is released on PyPI but exclude-newer rules in haystack-tutorials prevent the installation until June 15 noon https://github.com/deepset-ai/haystack-tutorials/blob/a35166953cbf83deb91d8642873364dccb0f2bf6/uv.toml#L3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
