### PR TITLE
Centralize uv config using uv.toml

### DIFF
--- a/.github/workflows/run_tutorials.yml
+++ b/.github/workflows/run_tutorials.yml
@@ -97,12 +97,10 @@ jobs:
             VERSION="${{ matrix.haystack_version }}"
             uv pip install "haystack-ai==${VERSION#v}"
           fi
-          uv pip install --exclude-newer P3D nbconvert ipython  # P3D = 3-day cutoff; haystack-ai above is exempt
+          uv pip install nbconvert ipython
 
       - name: Install tutorial dependencies
         if: toJSON(matrix.dependencies) != '[]'
-        env:
-          UV_EXCLUDE_NEWER: P3D  # reject packages uploaded within the last 3 days (supply chain protection)
         run: |
           uv pip install "${{ join(matrix.dependencies, '" "')}}"
 

--- a/uv.toml
+++ b/uv.toml
@@ -2,6 +2,6 @@
 # attacks via compromised dependencies.
 exclude-newer = "P3D"
 
-# first-party dependencies can be excluded from the global cutoff by uncommenting the following lines
-# [exclude-newer-package]
-# haystack-ai = false
+# first-party dependencies can be excluded from the global cutoff by adding entries below
+[exclude-newer-package]
+haystack-ai = false

--- a/uv.toml
+++ b/uv.toml
@@ -1,0 +1,7 @@
+# Exclude package versions published within the last 3 days to protect against supply chain
+# attacks via compromised dependencies.
+exclude-newer = "P3D"
+
+# first-party dependencies can be excluded from the global cutoff by uncommenting the following lines
+# [exclude-newer-package]
+# haystack-ai = false


### PR DESCRIPTION
Lately, I've sometimes gotten CI failures due to the `exclude-newer` package setting.

So, as a first step, I am centralizing the uv config in a uv.toml file (I have confirmed locally that this works correctly).

We can then remove first-party packages from the `exclude-newer` package setting if needed. If we set `haystack-ai = false`, this means that Haystack is not restricted, but its subdependencies are still restricted to be older than 3 days.