### PR TITLE
Update tutorial 32 to use the langdetect-haystack integration

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -75,7 +75,7 @@ notebook = "32_Classifying_Documents_and_Queries_by_Language.ipynb"
 aliases = []
 completion_time = "15 min"
 created_at = 2024-02-06
-dependencies = ["langdetect"]
+dependencies = ["langdetect-haystack"]
 
 [[tutorial]]
 title = "Creating a Hybrid Retrieval Pipeline"

--- a/tutorials/32_Classifying_Documents_and_Queries_by_Language.ipynb
+++ b/tutorials/32_Classifying_Documents_and_Queries_by_Language.ipynb
@@ -56,7 +56,7 @@
     "%%bash\n",
     "\n",
     "pip install haystack-ai\n",
-    "pip install langdetect"
+    "pip install langdetect-haystack"
    ]
   },
   {
@@ -91,7 +91,7 @@
    "source": [
     "from haystack import Document, Pipeline\n",
     "from haystack.document_stores.in_memory import InMemoryDocumentStore\n",
-    "from haystack.components.classifiers import DocumentLanguageClassifier\n",
+    "from haystack_integrations.components.classifiers.langdetect import DocumentLanguageClassifier\n",
     "from haystack.components.routers import MetadataRouter\n",
     "from haystack.components.writers import DocumentWriter\n",
     "\n",
@@ -389,7 +389,7 @@
     "from haystack.components.builders import ChatPromptBuilder\n",
     "from haystack.components.generators.chat import OpenAIChatGenerator\n",
     "from haystack.dataclasses import ChatMessage\n",
-    "from haystack.components.routers import TextLanguageRouter\n",
+    "from haystack_integrations.components.routers.langdetect import TextLanguageRouter\n",
     "\n",
     "prompt_template = [\n",
     "    ChatMessage.from_user(\n",


### PR DESCRIPTION
Updates tutorial 32 ("Classifying Documents & Queries by Language") to use the new `langdetect-haystack` integration package, since `DocumentLanguageClassifier` and `TextLanguageRouter` have moved out of Haystack core.

❗ **Requires PR https://github.com/deepset-ai/haystack-tutorials/pull/468 to be merged before to add langdetect-haystack as an exception of uv exclude-newer setting. Otherwise tutorial ci run will fail.**

### Changes
- install command: `pip install langdetect` → `pip install langdetect-haystack`
- imports:
  - `from haystack.components.classifiers import DocumentLanguageClassifier` → `from haystack_integrations.components.classifiers.langdetect import DocumentLanguageClassifier`
  - `from haystack.components.routers import TextLanguageRouter` → `from haystack_integrations.components.routers.langdetect import TextLanguageRouter`

### How I tested it
Ran the full notebook end-to-end against the `langdetect-haystack` package (installed from the integration branch) with a real `OPENAI_API_KEY`:
- classification wrote 2 English, 3 French, and 2 Spanish documents (no `unmatched`)
- the multi-lingual RAG pipeline answered both the English and Spanish queries correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
