### PR TITLE
Add haystack-experimental to first-party dependencies

### DIFF
--- a/scripts/generate_uv_excludes.py
+++ b/scripts/generate_uv_excludes.py
@@ -27,7 +27,7 @@ import sys
 from pathlib import Path
 
 # Packages that are first-party but not part of haystack-core-integrations.
-ALWAYS_INCLUDE = ["haystack-ai"]
+ALWAYS_INCLUDE = ["haystack-ai", "haystack-experimental"]
 
 HEADER = """\
 # Exclude package versions published within the last 3 days to protect against supply chain

--- a/uv.toml
+++ b/uv.toml
@@ -11,6 +11,7 @@ exclude-newer = "P3D"
 # script rather than this list by hand.
 [exclude-newer-package]
 haystack-ai = false
+haystack-experimental = false
 agent-pack-haystack = false
 aimlapi-haystack = false
 alloydb-haystack = false


### PR DESCRIPTION
Haystack experimental is not on the list of first-party dependencies, so recent versions cannot be installed and `exclude-newer-package` uv rule is applied.

Failures: https://github.com/deepset-ai/haystack-tutorials/actions/runs/30593570945/job/91041003052#step:5:22

I'm adding it