### PR TITLE
fix: test with latest stable Haystack release; avoid nltk 3.10.1

### DIFF
--- a/.github/workflows/run_tutorials.yml
+++ b/.github/workflows/run_tutorials.yml
@@ -26,7 +26,8 @@ jobs:
         run: |
           # Get tutorial notebooks
           VERSION=$(gh api /repos/deepset-ai/haystack/releases | \
-            jq -r '[.[].tag_name | select(test("^v2.[0-9]+.[0-9]+$"))] | first')
+            jq -r '[.[].tag_name | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] |
+                   max_by(.[1:] | split(".") | map(tonumber))')
           NOTEBOOKS=$(python ./scripts/generate_matrix.py --haystack-version "$VERSION" --include-main)
           echo "matrix={\"include\":$NOTEBOOKS}" >> "$GITHUB_OUTPUT"
 

--- a/index.toml
+++ b/index.toml
@@ -165,7 +165,8 @@ notebook = "42_Sentence_Window_Retriever.ipynb"
 aliases = []
 completion_time = "10 min"
 created_at = 2024-10-16
-dependencies = ["nltk"]
+# https://github.com/nltk/nltk/issues/3730
+dependencies = ["nltk!=3.10.1"]
 
 [[tutorial]]
 title = "Evaluation"


### PR DESCRIPTION
Tutorials using NLTK are failing (https://github.com/deepset-ai/haystack-tutorials/actions/runs/30963264985/job/92232254749) due to https://github.com/nltk/nltk/issues/3730 -> they are about to release a new version but in the meantime I modify the pin to avoid this version

I noticed that we were still testing with Haystack 2.31.0 and main -> modified the regex to use the latest stable version (currently 3.0.0)  and main