### PR TITLE
feat: Update agent pack tutorial

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -272,5 +272,5 @@ notebook = "50_Using_Pre_Built_Agents_from_Agent_Pack.ipynb"
 aliases = []
 completion_time = "25 min"
 created_at = 2026-07-20
-dependencies = ["haystack-ai>=3.0", "agent-pack-haystack", "arrow", "tavily-haystack", "trafilatura", "pypdf"]
+dependencies = ["haystack-ai>=3.1", "agent-pack-haystack", "arrow", "tavily-haystack", "trafilatura", "pypdf"]
 featured = false

--- a/tutorials/50_Using_Pre_Built_Agents_from_Agent_Pack.ipynb
+++ b/tutorials/50_Using_Pre_Built_Agents_from_Agent_Pack.ipynb
@@ -10,7 +10,7 @@
     "- **Level**: Advanced\n",
     "- **Time to complete**: 25 minutes\n",
     "- **Components/Packages Used**: [`agent-pack-haystack`](https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack) ([`create_advanced_rag_agent`](https://docs.haystack.deepset.ai/docs/advanced-rag-agent), [`create_deep_research_agent`](https://docs.haystack.deepset.ai/docs/deep-research-agent)), [`Agent`](https://docs.haystack.deepset.ai/docs/agent), [`InMemoryDocumentStore`](https://docs.haystack.deepset.ai/docs/inmemorydocumentstore)\n",
-    "- **Prerequisites**: Haystack 3.0 or later, an [OpenAI API key](https://platform.openai.com/api-keys), and a [Tavily API key](https://app.tavily.com) (free tier available)\n",
+    "- **Prerequisites**: Haystack 3.1 or later, an [OpenAI API key](https://platform.openai.com/api-keys), and a [Tavily API key](https://app.tavily.com) (free tier available)\n",
     "- **Goal**: After completing this tutorial, you'll understand what Agent Pack is and why it exists, and you'll have run and customized two ready-made agents: the **Advanced RAG Agent** and the **Deep Research Agent**."
    ]
   },
@@ -380,7 +380,7 @@
     "\n",
     "Each **sub-researcher** is its own `Agent` that searches the web (`web_search`), optionally reads promising pages (`read_url`, which fetches and summarizes a page or PDF toward the question), reflects (`think_tool`), and finishes by writing one short, cited summary.\n",
     "\n",
-    "The key idea is **context management**. Raw web content (search results, full pages, PDFs) is large and noisy; if it all piled into one context window, output quality would degrade. So each sub-researcher runs in its own private context, and only its short summary leaves it, controlled by two settings on the delegation tool: `outputs_to_string` (what the orchestrator sees) and `outputs_to_state` (what's appended to `notes` for the writer). The bulky raw research never propagates to the orchestrator or the writer."
+    "The key idea is **context management**. Raw web content (search results, full pages, PDFs) is large and noisy; if it all piled into one context window, output quality would degrade. So each sub-researcher runs in its own private context, and only its short summary leaves it. The delegation tool is an [`AgentTool`](https://docs.haystack.deepset.ai/docs/agenttool), which wraps the sub-researcher `Agent` and by default returns only its final message text to the orchestrator, while `outputs_to_state` appends that same summary to `notes` for the writer. The bulky raw research never propagates to the orchestrator or the writer."
    ]
   },
   {
@@ -423,7 +423,7 @@
     "\n",
     "Beyond running and customizing, the third way to use the pack is to **copy it**. Both agents are built entirely from public Haystack primitives, so their source doubles as a reference architecture:\n",
     "\n",
-    "- The Deep Research Agent shows how to nest agents (a sub-agent exposed to the orchestrator as a `ComponentTool`) and how `outputs_to_string` and `outputs_to_state` control what a sub-agent returns to the caller versus what it saves for later, the core of its context isolation.\n",
+    "- The Deep Research Agent shows how to nest agents (a sub-agent exposed to the orchestrator as an [`AgentTool`](https://docs.haystack.deepset.ai/docs/agenttool)) and how the tool's default text output and `outputs_to_state` control what a sub-agent returns to the caller versus what it saves for later, the core of its context isolation.\n",
     "- The Advanced RAG Agent shows how to build tools over a document store, embed a grammar in a tool's parameter description, accumulate results in `State`, and use an `after_run` hook as a safety net.\n",
     "\n",
     "Browse the source in [`haystack-core-integrations/integrations/agent_pack`](https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/agent_pack) and adapt whichever parts fit your use case."


### PR DESCRIPTION
Part of https://github.com/deepset-ai/haystack-private/issues/504 and related to https://github.com/deepset-ai/haystack-core-integrations/pull/3850

Update the agent pack to tutorial to reflect that we are now using AgentTool for the deep research agent in agent-pack