### PR TITLE
fix: replace retired Qwen2.5 model in tutorial 30

### DIFF
--- a/tutorials/30_File_Type_Preprocessing_Index_Pipeline.ipynb
+++ b/tutorials/30_File_Type_Preprocessing_Index_Pipeline.ipynb
@@ -312,7 +312,7 @@
     "id": "I06qdWsZibSz"
    },
    "source": [
-    "Now, let's build a RAG pipeline that answers queries based on the documents you just created in the section above. For this step, we will be using the [`HuggingFaceAPIChatGenerator`](https://docs.haystack.deepset.ai/docs/huggingfaceapichatgenerator) so must have a [Hugging Face API Key](https://huggingface.co/settings/tokens) for this section. We will be using the `Qwen/Qwen2.5-7B-Instruct` model."
+    "Now, let's build a RAG pipeline that answers queries based on the documents you just created in the section above. For this step, we will be using the [`HuggingFaceAPIChatGenerator`](https://docs.haystack.deepset.ai/docs/huggingfaceapichatgenerator) so must have a [Hugging Face API Key](https://huggingface.co/settings/tokens) for this section. We will be using the `Qwen/Qwen3.5-9B` model."
    ]
   },
   {
@@ -409,7 +409,8 @@
     "    \"llm\",\n",
     "    HuggingFaceAPIChatGenerator(\n",
     "        api_type=\"serverless_inference_api\",\n",
-    "        api_params={\"model\": \"Qwen/Qwen2.5-7B-Instruct\", \"provider\": \"together\"}\n",
+    "        api_params={\"model\": \"Qwen/Qwen3.5-9B\", \"provider\": \"together\"},\n",
+    "        generation_kwargs={\"extra_body\": {\"chat_template_kwargs\": {\"enable_thinking\": False}}}\n",
     "    ),\n",
     ")\n",
     "\n",
@@ -448,7 +449,7 @@
     "id": "ZJueu_V4KP6w"
    },
    "source": [
-    "{'llm': {'replies': [ChatMessage(_role=<ChatRole.ASSISTANT: 'assistant'>, _content=[TextContent(text='To make vegan keto eggplant lasagna, vegan persimmon flan, and vegan hemp cheese, you would need the following ingredients:\\n\\n### Vegan Keto Eggplant Lasagna\\n- 2 large eggplants\\n- Salt (Hella salt)\\n- 1/2 cup store-bought vegan mozzarella for topping\\n- Pesto (ingredients: 4 oz basil, 1/4 cup almonds, 1/4 cup nutritional yeast, 1/4 cup olive oil, 1 recipe vegan pesto)\\n- Spinach Tofu Ricotta (14 oz firm or extra firm tofu, 10 oz spinach, juice of 1 lemon, garlic powder to taste, salt to taste)\\n- Macadamia Nut Cheese (1 cup macadamia nuts, 1/4 cup nutritional yeast, 1/4 cup olive oil, 1 recipe vegan pesto, 1 recipe spinach tofu ricotta, 1 tsp garlic powder, juice of half a lemon, salt to taste)\\n\\n### Vegan Persimmon Flan\\n- 2 average-sized fuyu persimmons, strained\\n- 1 tbsp cornstarch\\n- 1/2 tsp agar agar\\n- 1 tbsp agave nectar, or to taste\\n- 2 tbsp granulated sugar\\n- 1/4 cup coconut creme\\n- 1/2 cup almond milk\\n- 1/2 tsp vanilla\\n\\n### Vegan Hemp Cheese\\n- 1/2 cup sunflower seeds\\n- 1/2 cup hemp hearts\\n- 1.5 teaspoons miso paste\\n- 1 tsp nutritional yeast\\n- 1/4 cup rejuvelac\\n- 1/4th teaspoon salt, or to taste\\n\\n### Additional Tools and Notes\\n- Casserole dish (9 x 13)\\n- 2 ramekins\\n- Blender or food processor\\n- Saucepan\\n- Immersion blender (optional)\\n- Clean glass bowl\\n- Rubber band\\n- Dish towel\\n- Knife\\n- Hot water bath method (for flan)\\n\\nThese ingredients and tools will allow you to prepare all three dishes as described in the provided context.')], _name=None, _meta={'model': 'Qwen/Qwen2.5-7B-Instruct', 'finish_reason': 'stop', 'index': 0, 'usage': {'prompt_tokens': 2031, 'completion_tokens': 446}})]}}"
+    "{'llm': {'replies': [ChatMessage(_role=<ChatRole.ASSISTANT: 'assistant'>, _content=[TextContent(text='To make vegan keto eggplant lasagna, vegan persimmon flan, and vegan hemp cheese, you would need the following ingredients:\\n\\n### Vegan Keto Eggplant Lasagna\\n- 2 large eggplants\\n- Salt (Hella salt)\\n- 1/2 cup store-bought vegan mozzarella for topping\\n- Pesto (ingredients: 4 oz basil, 1/4 cup almonds, 1/4 cup nutritional yeast, 1/4 cup olive oil, 1 recipe vegan pesto)\\n- Spinach Tofu Ricotta (14 oz firm or extra firm tofu, 10 oz spinach, juice of 1 lemon, garlic powder to taste, salt to taste)\\n- Macadamia Nut Cheese (1 cup macadamia nuts, 1/4 cup nutritional yeast, 1/4 cup olive oil, 1 recipe vegan pesto, 1 recipe spinach tofu ricotta, 1 tsp garlic powder, juice of half a lemon, salt to taste)\\n\\n### Vegan Persimmon Flan\\n- 2 average-sized fuyu persimmons, strained\\n- 1 tbsp cornstarch\\n- 1/2 tsp agar agar\\n- 1 tbsp agave nectar, or to taste\\n- 2 tbsp granulated sugar\\n- 1/4 cup coconut creme\\n- 1/2 cup almond milk\\n- 1/2 tsp vanilla\\n\\n### Vegan Hemp Cheese\\n- 1/2 cup sunflower seeds\\n- 1/2 cup hemp hearts\\n- 1.5 teaspoons miso paste\\n- 1 tsp nutritional yeast\\n- 1/4 cup rejuvelac\\n- 1/4th teaspoon salt, or to taste\\n\\n### Additional Tools and Notes\\n- Casserole dish (9 x 13)\\n- 2 ramekins\\n- Blender or food processor\\n- Saucepan\\n- Immersion blender (optional)\\n- Clean glass bowl\\n- Rubber band\\n- Dish towel\\n- Knife\\n- Hot water bath method (for flan)\\n\\nThese ingredients and tools will allow you to prepare all three dishes as described in the provided context.')], _name=None, _meta={'model': 'Qwen/Qwen3.5-9B', 'finish_reason': 'stop', 'index': 0, 'usage': {'prompt_tokens': 2031, 'completion_tokens': 446}})]}}"
    ]
   },
   {


### PR DESCRIPTION
### Related Issues

None. Found while investigating the nightly failure in [run 33136680751](https://github.com/deepset-ai/haystack-tutorials/actions/runs/33136680751); companion to deepset-ai/haystack-core-integrations#3866

`Qwen/Qwen2.5-7B-Instruct` + `provider="together"` routes to Together's `Qwen2.5-7B-Instruct-Turbo`, which Together retired from serverless. HF's API now reports that provider mapping as `status=error`, and the model is absent from `router.huggingface.co/v1/models`

### Proposed Changes:

- Swapped to **`Qwen/Qwen3.5-9B`** (same provider) — recent, small, cheap, live on `together`, and now consistent with the model used in the `huggingface_api` integration tests.
- Added `generation_kwargs={"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}}`. Qwen3.5 is a hybrid-thinking model; left on, it spends **8× the completion tokens** on this tutorial's prompt (1292 vs 165)
- Updated the prose model mention and the model name in the illustrative sample-response block

### How did you test it?

Both tutorial 30 jobs pass on this PR

### Notes for the reviewer

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-tutorials/blob/main/Contributing.md) and the [code of conduct](https://github.com/deepset-ai/haystack-tutorials/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes — n/a, no issue
- I added unit tests and updated the docstrings — n/a, tutorial notebook change
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
