### PR TITLE
docs: drop OpenAIGenerator comparison from tutorial 40

### DIFF
--- a/tutorials/40_Building_Chat_Application_with_Function_Calling.ipynb
+++ b/tutorials/40_Building_Chat_Application_with_Function_Calling.ipynb
@@ -89,7 +89,7 @@
    "source": [
     "## Learning about the OpenAIChatGenerator\n",
     "\n",
-    "[OpenAIChatGenerator](https://docs.haystack.deepset.ai/docs/openaichatgenerator) is a component that supports the function calling feature of OpenAI through Chat Completion API. In contrary to `OpenAIGenerator`, the way to communicate with `OpenAIChatGenerator` is through [`ChatMessage`](https://docs.haystack.deepset.ai/docs/data-classes#chatmessage) list. Read more about the difference between them in [Generators vs Chat Generators](https://docs.haystack.deepset.ai/docs/generators-vs-chat-generators).\n",
+    "[OpenAIChatGenerator](https://docs.haystack.deepset.ai/docs/openaichatgenerator) is a component that supports the function calling feature of OpenAI through Chat Completion API. The way to communicate with `OpenAIChatGenerator` is through a list of [`ChatMessage`](https://docs.haystack.deepset.ai/docs/data-classes#chatmessage) objects.\n",
     "\n",
     "\n",
     "To start working with the `OpenAIChatGenerator`, create a `ChatMessage` object with \"SYSTEM\" role using `ChatMessage.from_system()` and another `ChatMessage` with \"USER\" role using `ChatMessage.from_user()`. Then, pass this messages list to `OpenAIChatGenerator` and run:"


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/394

### Proposed Changes:

- Tutorial 40, "Learning about the OpenAIChatGenerator": drop the sentence contrasting `OpenAIChatGenerator` with `OpenAIGenerator` and the link to the "Generators vs Chat Generators" guide. `OpenAIGenerator` was removed in Haystack 3.0 and the guide no longer exists.
- This was the only mention of a removed non-chat Generator in the tutorials repo (searched for the core generators removed in 3.0 and the core-integration generators being removed now).

### How did you test it?

Markdown-only change in one cell; the notebook was not re-executed. Validated the notebook JSON and ran `pre-commit run --files` on it (black-jupyter, check-ast: passed). `index.toml` needs no change.

### Notes for the reviewer

Companion PRs: the core-integration generators are being removed in draft PRs in haystack-core-integrations, docs pages and redirects are handled in deepset-ai/haystack.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack-tutorials/blob/main/Contributing.md)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings — n/a, tutorial prose only
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
